### PR TITLE
Rename the repository from snowplow-objc-tracker to snowplow-ios-tracker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Examples"]
 	path = Examples
-	url = https://github.com/snowplow-incubator/snowplow-objc-tracker-examples
+	url = https://github.com/snowplow-incubator/snowplow-ios-tracker-examples

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ If you see an issue you would like to work on, please let us know in the issue! 
 not doubling the amount of work.
 
 If you don't know where to start contributing, you can look at
-[the issues labeled `good first issue`](https://github.com/snowplow/snowplow-objc-tracker/labels/category%3Agood_first_issue).
+[the issues labeled `good first issue`](https://github.com/snowplow/snowplow-ios-tracker/labels/category%3Agood_first_issue).
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ With this tracker you can collect event data from your applications, games or fr
 
 ### Demo apps using the Snowplow iOS Tracker
 
-Some examples of demo apps instrumented with our iOS Tracker can be found in the [snowplow-objc-tracker-examples](https://github.com/snowplow-incubator/snowplow-objc-tracker-examples) repository.
+Some examples of demo apps instrumented with our iOS Tracker can be found in the [snowplow-ios-tracker-examples](https://github.com/snowplow-incubator/snowplow-ios-tracker-examples) repository.
 
 ### Instrument the iOS Tracker
 
@@ -58,14 +58,14 @@ limitations under the License.
 [docs]: https://docs.snowplow.io/
 [mobile-docs]: https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/mobile-trackers/
 
-[gh-actions]: https://github.com/snowplow/snowplow-objc-tracker/actions
-[gh-actions-image]: https://github.com/snowplow/snowplow-objc-tracker/workflows/Build/badge.svg
+[gh-actions]: https://github.com/snowplow/snowplow-ios-tracker/actions
+[gh-actions-image]: https://github.com/snowplow/snowplow-ios-tracker/workflows/Build/badge.svg
 
-[coveralls]: https://coveralls.io/github/snowplow/snowplow-objc-tracker?branch=master
-[coveralls-image]: https://coveralls.io/repos/github/snowplow/snowplow-objc-tracker/badge.svg?branch=master
+[coveralls]: https://coveralls.io/github/snowplow/snowplow-ios-tracker?branch=master
+[coveralls-image]: https://coveralls.io/repos/github/snowplow/snowplow-ios-tracker/badge.svg?branch=master
 
 [license]: https://www.apache.org/licenses/LICENSE-2.0
-[license-image]: https://img.shields.io/github/license/snowplow/snowplow-objc-tracker
+[license-image]: https://img.shields.io/github/license/snowplow/snowplow-ios-tracker
 
 [cocoadocs]: https://cocoadocs.org/docsets/SnowplowTracker
 [cocoa-version]: https://cocoapod-badges.herokuapp.com/v/SnowplowTracker/badge.png
@@ -80,7 +80,7 @@ limitations under the License.
 [tech-docs]: https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/mobile-trackers/
 [tech-docs-image]: https://d3i6fms1cm1j0i.cloudfront.net/github/images/techdocs.png
 
-[api-docs]: https://snowplow.github.io/snowplow-objc-tracker/documentation/snowplowtracker/snowplow/
+[api-docs]: https://snowplow.github.io/snowplow-ios-tracker/documentation/snowplowtracker/snowplow/
 
 [contributing-image]: https://d3i6fms1cm1j0i.cloudfront.net/github/images/contributing.png
 

--- a/SnowplowTracker.podspec
+++ b/SnowplowTracker.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
     s.screenshots      = "https://d3i6fms1cm1j0i.cloudfront.net/github-wiki/images/snowplow-logo-large.png"
     s.license          = 'Apache License, Version 2.0'
     s.author           = { "Snowplow Analytics Ltd" => "support@snowplow.io" }
-    s.source           = { :git => "https://github.com/snowplow/snowplow-objc-tracker.git", :tag => s.version.to_s }
+    s.source           = { :git => "https://github.com/snowplow/snowplow-ios-tracker.git", :tag => s.version.to_s }
     s.social_media_url = 'https://twitter.com/SnowPlowData'
     s.documentation_url	= 'https://github.com/snowplow/snowplow/wiki/iOS-Tracker'
   


### PR DESCRIPTION
Rename references to the Github repository from `snowplow-objc-tracker` to `snowplow-ios-tracker`.