### PR TITLE
Fix validation errors due to session schema tracked without required previousSessionId property when anonymous tracking (close #767)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
             sdk: iphonesimulator14.0
             destination: "platform=iOS Simulator,OS=14.0,name=iPhone 11"
           - name: "xcodebuild (iOS 15.2, Xcode 13.2.1)"
-            os: macos-11
+            os: macos-12
             xcode-version: "13.2.1"
             sdk: iphonesimulator15.2
             destination: "platform=iOS Simulator,OS=15.2,name=iPhone 13"
@@ -41,7 +41,7 @@ jobs:
             sdk: macosx12.1
             destination: "platform=OS X"
           - name: "xcodebuild (watchOS 8.3, Xcode 13.2.1)"
-            os: macos-11
+            os: macos-12
             xcode-version: "13.2.1"
             sdk: watchos8.3
             destination: "platform=watchOS Simulator,OS=8.3,name=Apple Watch Series 7 - 45mm"
@@ -51,7 +51,7 @@ jobs:
             sdk: appletvsimulator14.0
             destination: "platform=tvOS Simulator,OS=14.0,name=Apple TV"
           - name: "xcodebuild (tvOS 15.2, Xcode 13.2.1)"
-            os: macos-11
+            os: macos-12
             xcode-version: "13.2.1"
             sdk: appletvsimulator15.2
             destination: "platform=tvOS Simulator,OS=15.2,name=Apple TV"

--- a/Sources/Core/Session/Session.swift
+++ b/Sources/Core/Session/Session.swift
@@ -145,7 +145,7 @@ class Session {
             // mask the user identifier
             var copy = context
             copy?[kSPSessionUserId] = kSPSessionAnonymousUserId
-            copy?[kSPSessionPreviousId] = nil
+            copy?[kSPSessionPreviousId] = NSNull()
             return copy
         } else {
             return context

--- a/Tests/TestSession.swift
+++ b/Tests/TestSession.swift
@@ -454,7 +454,7 @@ class TestSession: XCTestCase {
 
         let withAnonymisation = session.getDictWithEventId("event_3", eventTimestamp: 1654496481347, userAnonymisation: true)
         XCTAssertEqual("00000000-0000-0000-0000-000000000000", withAnonymisation?[kSPSessionUserId] as? String)
-        XCTAssertNil(withAnonymisation?[kSPSessionPreviousId])
+        XCTAssertEqual(NSNull(), withAnonymisation?[kSPSessionPreviousId] as? NSNull)
     }
 
     // Service methods


### PR DESCRIPTION
Issue #767 

Fixes a bug introduced in v5 of the tracker where the `previousSessionId` was not tracked in the `client_session` context entity in case anonymous tracking was enabled. This caused validation errors.

The fix is by setting the property to `NSNull` which ensures that it will be serialized as null in the JSON.