### PR TITLE
Fix remote config negative hash bug

### DIFF
--- a/Sources/Core/RemoteConfiguration/ConfigurationCache.swift
+++ b/Sources/Core/RemoteConfiguration/ConfigurationCache.swift
@@ -120,7 +120,7 @@ class ConfigurationCache: NSObject {
             }
         } catch {
         }
-        let fileName = String(format: "remoteConfig-%lu.data", UInt((remoteConfiguration.endpoint).hash))
+        let fileName = String(format: "remoteConfig-%lu.data", UInt(abs((remoteConfiguration.endpoint).hash)))
         url = url?.appendingPathComponent(fileName, isDirectory: false)
         if let url = url {
             cacheFileUrl = url


### PR DESCRIPTION
A bug was reported when using certain remote config URIs. If the URI hash was negative, the tracker crashed with "Fatal error: Negative value is not representable" due to the negative number being passed to `UInt`.