### PR TITLE
Fix memory leak when tracker is created using remote configuration (close #776)

### DIFF
--- a/Sources/Core/Session/Session.swift
+++ b/Sources/Core/Session/Session.swift
@@ -28,7 +28,7 @@ class Session {
     /// The event index
     private(set) var eventIndex = 0
     /// The current tracker associated with the session
-    private(set) var tracker: Tracker?
+    private(set) weak var tracker: Tracker?
     /// Returns the current session state
     private(set) var state: SessionState?
     /// Callback to be called when the session is updated


### PR DESCRIPTION
Issue #776 

The memory leak was in the `Session` class which holds a reference to the tracker. Since the reference was strong, the tracker was kept in memory even in case it was no longer referenced in `ServiceProvider`.

I changed it to a weak reference which means that the lifetime of the tracker object is no longer determined by that reference.