### PR TITLE
Handle unprotected access to sending state in Emitter from concurrent threads (close #774)

### DIFF
--- a/Sources/Core/Emitter/Emitter.swift
+++ b/Sources/Core/Emitter/Emitter.swift
@@ -550,7 +550,7 @@ fileprivate class SendingCheck {
         }
     }
     
-    private func lock<T: Any>(closure: () -> T) -> T {
+    private func lock<T>(closure: () -> T) -> T {
         objc_sync_enter(self)
         defer { objc_sync_exit(self) }
         return closure()


### PR DESCRIPTION
Addresses issue #774 that reported a problem with concurrent access to the `isSending` property in Emitter which wasn't thread-safe.

To address the problem, this PR creates a wrapper class `SendingLock` around the `isSending` property that protects access to the value using a lock.