### PR TITLE
Add a filter API to plugins to decide whether to track an event or not (close #783)

### DIFF
--- a/Sources/Core/GlobalContexts/GlobalContextPluginConfiguration.swift
+++ b/Sources/Core/GlobalContexts/GlobalContextPluginConfiguration.swift
@@ -13,10 +13,9 @@
 
 import Foundation
 
-class GlobalContextPluginConfiguration: ConfigurationProtocol, PluginConfigurationProtocol {
+class GlobalContextPluginConfiguration: ConfigurationProtocol, PluginIdentifiable, PluginEntitiesCallable {
     private(set) var identifier: String
     private(set) var globalContext: GlobalContext
-    private(set) var afterTrackConfiguration: PluginAfterTrackConfiguration? = nil
     private(set) var entitiesConfiguration: PluginEntitiesConfiguration?
 
     init(identifier: String, globalContext: GlobalContext) {

--- a/Sources/Core/ScreenViewTracking/ScreenStateMachine.swift
+++ b/Sources/Core/ScreenViewTracking/ScreenStateMachine.swift
@@ -32,6 +32,10 @@ class ScreenStateMachine: StateMachineProtocol {
     var subscribedEventSchemasForAfterTrackCallback: [String] {
         return []
     }
+    
+    var subscribedEventSchemasForFiltering: [String] {
+        return []
+    }
 
     func transition(from event: Event, state currentState: State?) -> State? {
         if let screenView = event as? ScreenView {
@@ -59,6 +63,10 @@ class ScreenStateMachine: StateMachineProtocol {
             addedValues[kSPSvPreviousScreenId] = previousState?.screenId
             return addedValues
         }
+        return nil
+    }
+
+    func filter(event: InspectableEvent, state: State?) -> Bool? {
         return nil
     }
 

--- a/Sources/Core/StateMachine/DeepLinkStateMachine.swift
+++ b/Sources/Core/StateMachine/DeepLinkStateMachine.swift
@@ -44,6 +44,10 @@ class DeepLinkStateMachine: StateMachineProtocol {
     var subscribedEventSchemasForAfterTrackCallback: [String] {
         return []
     }
+    
+    var subscribedEventSchemasForFiltering: [String] {
+        return []
+    }
 
     func transition(from event: Event, state: State?) -> State? {
         if let dlEvent = event as? DeepLinkReceived {
@@ -70,6 +74,10 @@ class DeepLinkStateMachine: StateMachineProtocol {
             entity.referrer = deepLinkState.referrer
             return [entity]
         }
+        return nil
+    }
+    
+    func filter(event: InspectableEvent, state: State?) -> Bool? {
         return nil
     }
 

--- a/Sources/Core/StateMachine/LifecycleStateMachine.swift
+++ b/Sources/Core/StateMachine/LifecycleStateMachine.swift
@@ -63,4 +63,12 @@ class LifecycleStateMachine: StateMachineProtocol {
 
     func afterTrack(event: InspectableEvent) {
     }
+    
+    var subscribedEventSchemasForFiltering: [String] {
+        return []
+    }
+    
+    func filter(event: InspectableEvent, state: State?) -> Bool? {
+        return nil
+    }
 }

--- a/Sources/Core/StateMachine/PluginStateMachine.swift
+++ b/Sources/Core/StateMachine/PluginStateMachine.swift
@@ -15,20 +15,24 @@ import Foundation
 
 typealias EntitiesConfiguration = (schemas: [String]?, closure: (InspectableEvent) -> ([SelfDescribingJson]))
 typealias AfterTrackConfiguration = (schemas: [String]?, closure: (InspectableEvent) -> ())
+typealias FilterConfiguration = (schemas: [String]?, closure: (InspectableEvent) -> Bool)
 
 class PluginStateMachine: StateMachineProtocol {
     var identifier: String
     private var entitiesConfiguration: EntitiesConfiguration?
     private var afterTrackConfiguration: AfterTrackConfiguration?
+    private var filterConfiguration: FilterConfiguration?
 
     init(
         identifier: String,
         entitiesConfiguration: EntitiesConfiguration?,
-        afterTrackConfiguration: AfterTrackConfiguration?
+        afterTrackConfiguration: AfterTrackConfiguration?,
+        filterConfiguration: FilterConfiguration?
     ) {
         self.identifier = identifier
         self.entitiesConfiguration = entitiesConfiguration
         self.afterTrackConfiguration = afterTrackConfiguration
+        self.filterConfiguration = filterConfiguration
     }
 
     var subscribedEventSchemasForTransitions: [String] {
@@ -80,5 +84,23 @@ class PluginStateMachine: StateMachineProtocol {
         if let afterTrackConfiguration = afterTrackConfiguration {
             afterTrackConfiguration.closure(event)
         }
+    }
+    
+    var subscribedEventSchemasForFiltering: [String] {
+        if let filterConfiguration = filterConfiguration {
+            if let schemas = filterConfiguration.schemas {
+                return schemas
+            } else {
+                return ["*"]
+            }
+        }
+        return []
+    }
+    
+    func filter(event: InspectableEvent, state: State?) -> Bool? {
+        if let filterConfiguration = filterConfiguration {
+            return filterConfiguration.closure(event)
+        }
+        return nil
     }
 }

--- a/Sources/Core/StateMachine/StateMachineProtocol.swift
+++ b/Sources/Core/StateMachine/StateMachineProtocol.swift
@@ -19,9 +19,13 @@ protocol StateMachineProtocol {
     var subscribedEventSchemasForEntitiesGeneration: [String] { get }
     var subscribedEventSchemasForPayloadUpdating: [String] { get }
     var subscribedEventSchemasForAfterTrackCallback: [String] { get }
+    var subscribedEventSchemasForFiltering: [String] { get }
     
     /// Only available for self-describing events (inheriting from SelfDescribingAbstract)
     func transition(from event: Event, state: State?) -> State?
+    
+    /// Available for both self-describing and primitive events (when using `*` as the schema)
+    func filter(event: InspectableEvent, state: State?) -> Bool?
     
     /// Available for both self-describing and primitive events (when using `*` as the schema)
     func entities(from event: InspectableEvent, state: State?) -> [SelfDescribingJson]?

--- a/Sources/Core/Tracker/PluginsControllerImpl.swift
+++ b/Sources/Core/Tracker/PluginsControllerImpl.swift
@@ -18,7 +18,7 @@ class PluginsControllerImpl: Controller, PluginsController {
         return serviceProvider.pluginConfigurations.map { $0.identifier }
     }
     
-    func add(plugin: PluginConfigurationProtocol) {
+    func add(plugin: PluginIdentifiable) {
         serviceProvider.addPlugin(plugin: plugin)
     }
 

--- a/Sources/Core/Tracker/ServiceProvider.swift
+++ b/Sources/Core/Tracker/ServiceProvider.swift
@@ -102,7 +102,7 @@ class ServiceProvider: NSObject, ServiceProviderProtocol {
     }
     
     // Original configurations
-    private(set) var pluginConfigurations: [PluginConfigurationProtocol] = []
+    private(set) var pluginConfigurations: [PluginIdentifiable] = []
 
     // Configuration updates
     private(set) var networkConfigurationUpdate = NetworkConfigurationUpdate()
@@ -162,7 +162,7 @@ class ServiceProvider: NSObject, ServiceProviderProtocol {
                 for plugin in configuration.toPluginConfigurations() {
                     pluginConfigurations.append(plugin)
                 }
-            } else if let configuration = configuration as? PluginConfigurationProtocol {
+            } else if let configuration = configuration as? PluginIdentifiable {
                 pluginConfigurations.append(configuration)
             }
         }
@@ -343,7 +343,7 @@ class ServiceProvider: NSObject, ServiceProviderProtocol {
         return NetworkControllerImpl(serviceProvider: self)
     }
     
-    func addPlugin(plugin: PluginConfigurationProtocol) {
+    func addPlugin(plugin: PluginIdentifiable) {
         removePlugin(identifier: plugin.identifier)
         pluginConfigurations.append(plugin)
         tracker.addOrReplace(stateMachine: plugin.toStateMachine())

--- a/Sources/Core/Tracker/ServiceProviderProtocol.swift
+++ b/Sources/Core/Tracker/ServiceProviderProtocol.swift
@@ -33,7 +33,7 @@ protocol ServiceProviderProtocol: AnyObject {
     var subjectConfigurationUpdate: SubjectConfigurationUpdate { get }
     var sessionConfigurationUpdate: SessionConfigurationUpdate { get }
     var gdprConfigurationUpdate: GDPRConfigurationUpdate { get }
-    var pluginConfigurations: [PluginConfigurationProtocol] { get }
-    func addPlugin(plugin: PluginConfigurationProtocol)
+    var pluginConfigurations: [PluginIdentifiable] { get }
+    func addPlugin(plugin: PluginIdentifiable)
     func removePlugin(identifier: String)
 }

--- a/Sources/Snowplow/Configurations/PluginConfiguration.swift
+++ b/Sources/Snowplow/Configurations/PluginConfiguration.swift
@@ -17,6 +17,8 @@ import Foundation
 public typealias PluginAfterTrackClosure = (InspectableEvent) -> Void
 /// Closure used in plugin callbacks to generate entities.
 public typealias PluginEntitiesClosure = (InspectableEvent) -> [SelfDescribingJson]
+/// Closure used in plugin callbacks to decide whether to track the given event or not.
+public typealias PluginFilterClosure = (InspectableEvent) -> Bool
 
 /// Provides a block closure to be called after events are tracked.
 /// Optionally, you can specify the event schemas for which the block should be called.
@@ -60,31 +62,90 @@ public class PluginEntitiesConfiguration: NSObject {
     }
 }
 
-/// Protocol for tracker plugin definition.
-/// Specifies configurations for the closures called when and after events are tracked.
-@objc(SPPluginConfigurationProtocol)
-public protocol PluginConfigurationProtocol {
+/// Provides a closure that is called to decide whether to track a given event or not.
+/// - Parameters:
+///   - schemas: Optional list of event schemas to call the closure for. If null, the closure is called for all events.
+///   - closure: Closure block that returns true if the event should be tracked and false otherwise.
+@objc(SPPluginFilterConfiguration)
+public class PluginFilterConfiguration : NSObject {
+    var schemas: [String]?
+    var closure: PluginFilterClosure
+    
+    /// Creates the closure configuration
+    /// - Parameters:
+    ///   - schemas: Optional list of event schemas to call the closure for. If null, the closure is called for all events.
+    ///   - closure: Closure block that returns true if the event should be tracked and false otherwise.
+    public init(schemas: [String]? = nil, closure: @escaping PluginFilterClosure) {
+        self.schemas = schemas
+        self.closure = closure
+    }
+    
+    func toTuple() -> (schemas: [String]?, closure: PluginFilterClosure) {
+        return (schemas: schemas, closure: closure)
+    }
+}
+
+/// Identifies a tracker plugin with a unique identifier. Required for all plugins.
+@objc(SPPluginIdentifiable)
+public protocol PluginIdentifiable {
     /// Unique identifier of the plugin within the tracker.
     var identifier: String { get }
+}
+
+extension PluginIdentifiable {
+    func toStateMachine() -> StateMachineProtocol {
+        var entitiesConfiguration: PluginEntitiesConfiguration?
+        if let entitiesCallable = self as? PluginEntitiesCallable {
+            entitiesConfiguration = entitiesCallable.entitiesConfiguration
+        }
+        var afterTrackConfiguration: PluginAfterTrackConfiguration?
+        if let afterTrackCallable = self as? PluginAfterTrackCallable {
+            afterTrackConfiguration = afterTrackCallable.afterTrackConfiguration
+        }
+        var filterConfiguration: PluginFilterConfiguration?
+        if let filterCallable = self as? PluginFilterCallable {
+            filterConfiguration = filterCallable.filterConfiguration
+        }
+        return PluginStateMachine(
+            identifier: identifier,
+            entitiesConfiguration: entitiesConfiguration?.toTuple(),
+            afterTrackConfiguration: afterTrackConfiguration?.toTuple(),
+            filterConfiguration: filterConfiguration?.toTuple())
+    }
+}
+
+/// Protocol for a plugin that provides a closure to call after events are tracked.
+@objc(SPPluginAfterTrackCallable)
+public protocol PluginAfterTrackCallable {
     /// Closure configuration that is called after events are tracked.
     var afterTrackConfiguration: PluginAfterTrackConfiguration? { get }
+}
+
+/// Protocol for a plugin that provides a closure to generate context entities to enrich events.
+@objc(SPPluginEntitiesCallable)
+public protocol PluginEntitiesCallable {
     /// Closure configuration that is called when events are tracked to generate context entities to enrich the events.
     var entitiesConfiguration: PluginEntitiesConfiguration? { get }
 }
 
-extension PluginConfigurationProtocol {
-    func toStateMachine() -> StateMachineProtocol {
-        return PluginStateMachine(
-            identifier: identifier,
-            entitiesConfiguration: entitiesConfiguration?.toTuple(),
-            afterTrackConfiguration: afterTrackConfiguration?.toTuple())
-    }
+/// Protocol for a plugin that provides a closure to decide whether to track events or not.
+@objc(SPPluginFilterCallable)
+public protocol PluginFilterCallable {
+    /// Closure configuration that is called when events are tracked to decide whether to track them or not.
+    var filterConfiguration: PluginFilterConfiguration? { get }
+}
+
+/// Protocol for tracker plugin definition.
+/// Specifies configurations for the closures called when and after events are tracked.
+@available(*, deprecated, message: "Use PluginIdentifiable, PluginAfterTrackCallable and PluginEntitiesCallable protocols instead")
+@objc(SPPluginConfigurationProtocol)
+public protocol PluginConfigurationProtocol : PluginIdentifiable, PluginAfterTrackCallable, PluginEntitiesCallable {
 }
 
 /// Configuration for a custom tracker plugin.
 /// Enables you to add closures to be called when and after events are tracked in the tracker.
 @objc(SPPluginConfiguration)
-public class PluginConfiguration: NSObject, PluginConfigurationProtocol, ConfigurationProtocol {
+public class PluginConfiguration: NSObject, PluginIdentifiable, PluginAfterTrackCallable, PluginEntitiesCallable, PluginFilterCallable, ConfigurationProtocol {
     /// Unique identifier of the plugin within the tracker.
     public private(set) var identifier: String
     /// Closure configuration that is called after events are tracked.
@@ -93,6 +154,8 @@ public class PluginConfiguration: NSObject, PluginConfigurationProtocol, Configu
     /// Closure configuration that is called when events are tracked to generate context entities to enrich the events.
     /// Read-only, use `entities(schemas:closure:)` to initialize.
     public private(set) var entitiesConfiguration: PluginEntitiesConfiguration?
+    /// Closure configuration that is called to decide whether to track a given event or not.
+    public private(set) var filterConfiguration: PluginFilterConfiguration?
 
     /// Create a plugin configuration.
     /// - Parameters:
@@ -122,6 +185,18 @@ public class PluginConfiguration: NSObject, PluginConfigurationProtocol, Configu
     ///   - closure: Closure block to call after events are tracked.
     public func afterTrack(schemas: [String]? = nil, closure: @escaping PluginAfterTrackClosure) -> Self {
         self.afterTrackConfiguration = PluginAfterTrackConfiguration(
+            schemas: schemas,
+            closure: closure
+        )
+        return self
+    }
+    
+    /// Add a closure that is called to decide whether to track a given event or not.
+    /// - Parameters:
+    ///   - schemas: Optional list of event schemas to call the closure for. If null, the closure is called for all events.
+    ///   - closure: Closure block that returns true if the event should be tracked and false otherwise.
+    public func filter(schemas: [String]? = nil, closure: @escaping PluginFilterClosure) -> Self {
+        self.filterConfiguration = PluginFilterConfiguration(
             schemas: schemas,
             closure: closure
         )

--- a/Sources/Snowplow/Controllers/PluginsController.swift
+++ b/Sources/Snowplow/Controllers/PluginsController.swift
@@ -18,7 +18,7 @@ public protocol PluginsController {
     @objc
     var identifiers: [String] { get }
     @objc
-    func add(plugin: PluginConfigurationProtocol)
+    func add(plugin: PluginIdentifiable)
     @objc
     func remove(identifier: String)
 }

--- a/Tests/Legacy Tests/LegacyTestTracker.swift
+++ b/Tests/Legacy Tests/LegacyTestTracker.swift
@@ -116,7 +116,7 @@ class LegacyTestTracker: XCTestCase {
         let event = Structured(category: "Category", action: "Action")
         let trackerEvent = TrackerEvent(event: event, state: nil)
         var payload = tracker.payload(with: trackerEvent)
-        var payloadDict = payload.dictionary
+        var payloadDict = payload!.dictionary
 
         XCTAssertEqual(payloadDict[kSPPlatform] as? String, devicePlatformToString(.general))
         XCTAssertEqual(payloadDict[kSPAppId] as? String, "anAppId")
@@ -129,7 +129,7 @@ class LegacyTestTracker: XCTestCase {
         tracker.trackerNamespace = "newNamespace"
 
         payload = tracker.payload(with: trackerEvent)
-        payloadDict = payload.dictionary
+        payloadDict = payload!.dictionary
 
         XCTAssertEqual(payloadDict[kSPPlatform] as? String, "pc")
         XCTAssertEqual(payloadDict[kSPAppId] as? String, "newAppId")

--- a/Tests/TestStateManager.swift
+++ b/Tests/TestStateManager.swift
@@ -79,6 +79,14 @@ class MockStateMachine: StateMachineProtocol {
 
     func afterTrack(event: SnowplowTracker.InspectableEvent) {
     }
+    
+    var subscribedEventSchemasForFiltering: [String] {
+        return ["s1"]
+    }
+    
+    func filter(event: InspectableEvent, state: State?) -> Bool? {
+        return false
+    }
 }
 
 class MockStateMachine1: MockStateMachine {
@@ -217,5 +225,23 @@ class TestStateManager: XCTestCase {
         stateManager.addOrReplaceStateMachine(MockStateMachine2("identifier"))
         let trackerState2 = stateManager.trackerState(forProcessedEvent: Structured(category: "category", action: "action"))
         XCTAssertNil(trackerState2?.state(withIdentifier: "identifier"))
+    }
+    
+    func testFilterReturnsSettingOfStateMachine() {
+        let stateManager = StateManager()
+        stateManager.addOrReplaceStateMachine(MockStateMachine1("identifier"))
+        
+        
+        XCTAssertFalse(
+            stateManager.filter(
+                event: TrackerEvent(event: SelfDescribing(schema: "s1", payload: [:]))
+            )
+        )
+
+        XCTAssertTrue(
+            stateManager.filter(
+                event: TrackerEvent(event: SelfDescribing(schema: "s2", payload: [:]))
+            )
+        )
     }
 }


### PR DESCRIPTION
Issue #783 

Adds a new `filter` callback to plugins which enables deciding whether to track an event or not. This can be useful for filtering auto-tracked events by the tracker.

For instance, this snippet filters screen view events to keep only ones with a specific name property:

```swift
plugin.filter(schemas: [
    "iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0", // screen view events
]) { event in
    return event.payload["name"] as? String == "Home Screen"
}
```

## Documentation

[Here is a commit adding the documentation for the filter function](https://github.com/snowplow/documentation/commit/79410621b205fdbbcc2ef3dd20264121e15a8238).