### PR TITLE
Fix emit range configuration in Emitter not respected if using SQLite event store (close #789)

### DIFF
--- a/Sources/Core/Storage/SQLiteEventStore.swift
+++ b/Sources/Core/Storage/SQLiteEventStore.swift
@@ -175,7 +175,7 @@ class SQLiteEventStore: NSObject, EventStore {
     }
 
     func emittableEvents(withQueryLimit queryLimit: UInt) -> [EmitterEvent] {
-        return getAllEventsLimited(UInt(sendLimit)) ?? []
+        return getAllEventsLimited(min(queryLimit, UInt(sendLimit))) ?? []
     }
 
     // MARK: SPSQLiteEventStore methods

--- a/Tests/Configurations/TestEmitterConfiguration.swift
+++ b/Tests/Configurations/TestEmitterConfiguration.swift
@@ -21,6 +21,7 @@ class TestEmitterConfiguration: XCTestCase {
     }
 
     override func tearDown() {
+        Snowplow.removeAllTrackers()
         super.tearDown()
     }
 
@@ -31,23 +32,18 @@ class TestEmitterConfiguration: XCTestCase {
         emitterConfig.bufferOption = .single
         let networkConfig = NetworkConfiguration(networkConnection: networkConnection)
 
-        let trackerConfig = TrackerConfiguration(appId: "appid")
-        trackerConfig.installAutotracking = false
-        trackerConfig.screenViewAutotracking = false
-        trackerConfig.lifecycleAutotracking = false
-        let tracker = Snowplow.createTracker(namespace: "namespace", network: networkConfig, configurations: [trackerConfig, emitterConfig])
-        XCTAssertNotNil(tracker)
+        let tracker = createTracker(networkConfig: networkConfig, emitterConfig: emitterConfig)
 
-        tracker?.emitter?.pause()
-        _ = tracker?.track(Structured(category: "cat", action: "act"))
-        Thread.sleep(forTimeInterval: 3)
-        XCTAssertEqual(1, tracker?.emitter?.dbCount)
+        tracker.emitter?.pause()
+        _ = tracker.track(Structured(category: "cat", action: "act"))
+        Thread.sleep(forTimeInterval: 1)
+        XCTAssertEqual(1, tracker.emitter?.dbCount)
         XCTAssertEqual(0, networkConnection.previousResults.count)
 
-        tracker?.emitter?.resume()
-        Thread.sleep(forTimeInterval: 3)
+        tracker.emitter?.resume()
+        Thread.sleep(forTimeInterval: 1)
         XCTAssertEqual(1, networkConnection.previousResults.count)
-        XCTAssertEqual(0, tracker?.emitter?.dbCount)
+        XCTAssertEqual(0, tracker.emitter?.dbCount)
     }
 
     func testActivatesServerAnonymisationInEmitter() {
@@ -56,9 +52,9 @@ class TestEmitterConfiguration: XCTestCase {
 
         let networkConfig = NetworkConfiguration(endpoint: "", method: .post)
 
-        let tracker = Snowplow.createTracker(namespace: "namespace", network: networkConfig, configurations: [emitterConfig])
+        let tracker = createTracker(networkConfig: networkConfig, emitterConfig: emitterConfig)
 
-        XCTAssertTrue(tracker?.emitter?.serverAnonymisation ?? false)
+        XCTAssertTrue(tracker.emitter?.serverAnonymisation ?? false)
     }
     
     func testRespectsEmitRange() {
@@ -68,23 +64,31 @@ class TestEmitterConfiguration: XCTestCase {
         emitterConfig.emitRange = 2
         let networkConfig = NetworkConfiguration(networkConnection: networkConnection)
 
-        let trackerConfig = TrackerConfiguration(appId: "appid")
+        let tracker = createTracker(networkConfig: networkConfig, emitterConfig: emitterConfig)
+
+        tracker.emitter?.pause()
+        for i in 0..<10 {
+            _ = tracker.track(Structured(category: "cat", action: "act").value(NSNumber(value: i)))
+        }
+        Thread.sleep(forTimeInterval: 1)
+        XCTAssertEqual(10, tracker.emitter?.dbCount)
+        XCTAssertEqual(0, networkConnection.previousResults.count)
+
+        tracker.emitter?.resume()
+        Thread.sleep(forTimeInterval: 1)
+        XCTAssertEqual(5, networkConnection.previousResults.count) // 5 requests for 10 events – emit range 2
+        XCTAssertEqual(0, tracker.emitter?.dbCount)
+    }
+    
+    private func createTracker(networkConfig: NetworkConfiguration, emitterConfig: EmitterConfiguration) -> TrackerController {
+        let trackerConfig = TrackerConfiguration()
         trackerConfig.installAutotracking = false
         trackerConfig.screenViewAutotracking = false
         trackerConfig.lifecycleAutotracking = false
-        let tracker = Snowplow.createTracker(namespace: "namespace", network: networkConfig, configurations: [trackerConfig, emitterConfig])
-        XCTAssertNotNil(tracker)
-
-        tracker?.emitter?.pause()
-        for i in 0..<10 {
-            _ = tracker?.track(Structured(category: "cat", action: "act").value(NSNumber(value: i)))
-        }
-        XCTAssertEqual(10, tracker?.emitter?.dbCount)
-        XCTAssertEqual(0, networkConnection.previousResults.count)
-
-        tracker?.emitter?.resume()
-        Thread.sleep(forTimeInterval: 3)
-        XCTAssertEqual(5, networkConnection.previousResults.count) // 5 requests for 10 events – emit range 2
-        XCTAssertEqual(0, tracker?.emitter?.dbCount)
+        let namespace = "testEmitter" + String(describing: Int.random(in: 0..<100))
+        return Snowplow.createTracker(namespace: namespace,
+                                      network: networkConfig,
+                                      configurations: [trackerConfig, emitterConfig])!
     }
+    
 }


### PR DESCRIPTION
Issue #789 

The `emitRange` Emitter configuration has been ignored in the `SQLiteEventStore` (it's a long standing bug). Instead, the event store only followed an internal setting for the send limit.

This PR fixes the issue by using the minimum of the Emitter `emitRange` and the event store `sendLimit` configuration when choosing how many events to emit from the store.