### PR TITLE
Truncate URL scheme for page_url and page_refr properties (close #793)

### DIFF
--- a/Sources/Core/Tracker/Tracker.swift
+++ b/Sources/Core/Tracker/Tracker.swift
@@ -556,10 +556,10 @@ class Tracker: NSObject {
         }
 
         if let url = url {
-            payload.addValueToPayload(url, forKey: kSPPageUrl)
+            payload.addValueToPayload(Utilities.truncateUrlScheme(url), forKey: kSPPageUrl)
         }
         if let referrer = referrer {
-            payload.addValueToPayload(referrer, forKey: kSPPageRefr)
+            payload.addValueToPayload(Utilities.truncateUrlScheme(referrer), forKey: kSPPageRefr)
         }
     }
 

--- a/Sources/Core/Utils/Utilities.swift
+++ b/Sources/Core/Utils/Utilities.swift
@@ -243,5 +243,17 @@ class Utilities {
     class var appBuild: String? {
         return Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as? String
     }
+    
+    /// Truncates the scheme of a URL to 16 characters to satisfy the validation for the page_url and page_refr properties.
+    class func truncateUrlScheme(_ url: String) -> String {
+        let parts = url.components(separatedBy: "://")
+        if parts.count > 1 {
+            if let scheme = parts.first?.prefix(16) {
+                let updatedParts = [String(scheme)] + Array(parts.dropFirst())
+                return updatedParts.joined(separator: "://")
+            }
+        }
+        return url
+    }
 }
 

--- a/Tests/TestEvents.swift
+++ b/Tests/TestEvents.swift
@@ -94,8 +94,8 @@ class TestEvents: XCTestCase {
 
     func testDeepLinkContextAndAtomicPropertiesAddedToScreenView() {
         // Prepare DeepLinkReceived event
-        let deepLink = DeepLinkReceived(url: "the_url")
-        deepLink.referrer = "the_referrer"
+        let deepLink = DeepLinkReceived(url: "someappwithaverylongscheme://the_url")
+        deepLink.referrer = "someappwithaverylongscheme://the_referrer"
 
         // Prepare ScreenView event
         let screenView = ScreenView(name: "SV", screenId: UUID())
@@ -131,14 +131,14 @@ class TestEvents: XCTestCase {
 
         // Check the DeepLink context entity properties
         let screenViewContext = screenViewPayload?["co"] as? String
-        XCTAssertTrue(screenViewContext?.contains("\"referrer\":\"the_referrer\"") ?? false)
-        XCTAssertTrue(screenViewContext?.contains("\"url\":\"the_url\"") ?? false)
+        XCTAssertTrue(screenViewContext?.contains("\"referrer\":\"someappwithaverylongscheme:\\/\\/the_referrer\"") ?? false)
+        XCTAssertTrue(screenViewContext?.contains("\"url\":\"someappwithaverylongscheme:\\/\\/the_url\"") ?? false)
 
         // Check url and referrer fields for atomic table
         let url = screenViewPayload?[kSPPageUrl] as? String
         let referrer = screenViewPayload?[kSPPageRefr] as? String
-        XCTAssertEqual(url, "the_url")
-        XCTAssertEqual(referrer, "the_referrer")
+        XCTAssertEqual(url, "someappwithavery://the_url")
+        XCTAssertEqual(referrer, "someappwithavery://the_referrer")
     }
 
     func testPageView() {

--- a/Tests/TestUtils.swift
+++ b/Tests/TestUtils.swift
@@ -157,6 +157,23 @@ class TestUtils: XCTestCase {
         XCTAssertEqual(result.count, 1)
     }
     
+    func testTruncateUrlSchemeDoesntChangeValidUrl() {
+        let url = "https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol/#snowplow-events"
+        XCTAssertEqual(url, Utilities.truncateUrlScheme(url))
+    }
+    
+    func testTruncateUrlSchemeDoesntChangeInvalidUrl() {
+        let url = "this is not a valid URL"
+        XCTAssertEqual(url, Utilities.truncateUrlScheme(url))
+    }
+    
+    func testTruncateUrlSchemeTruncatesLongUrlScheme() {
+        let url = "12345678901234567890://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol/#snowplow-events"
+        let expected = "1234567890123456://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol/#snowplow-events"
+        
+        XCTAssertEqual(expected, Utilities.truncateUrlScheme(url))
+    }
+    
     private func assertEqualUrlEncode(_ now: String, _ then: String) {
         XCTAssertEqual(
             Set<String>(now.split(separator: "&").map { String($0) }),


### PR DESCRIPTION
Issue #793

This PR addresses the issue that the URL scheme may be quite long for deep links but the atomic events schema limits the max length of the scheme to 16 characters for page_url and page_refr properties, [see here](https://github.com/snowplow/iglu-central/blob/master/schemas/com.snowplowanalytics.snowplow/atomic/jsonschema/1-0-0#L136). This can lead to validation errors when deep links with longer URL schemes are tracked.

To solve the issue, the tracker now truncates the URL scheme in page_url and page_refr properties to 16 chars. This only affects the values in the atomic properties, the URLs in the deep link event and context entity are not truncated.