### PR TITLE
Truncate language in platform context entity to max 8 characters (close #795)

### DIFF
--- a/Sources/Core/Subject/PlatformContext.swift
+++ b/Sources/Core/Subject/PlatformContext.swift
@@ -99,7 +99,8 @@ class PlatformContext {
             platformDict[kSPMobileResolution] = deviceInfoMonitor.resolution
         }
         if shouldTrack(.language) {
-            platformDict[kSPMobileLanguage] = deviceInfoMonitor.language
+            // the schema has a max-length 8 for language which iOS exceeds sometimes
+            if let language = deviceInfoMonitor.language { platformDict[kSPMobileLanguage] = String(language.prefix(8)) }
         }
         if shouldTrack(.scale) {
             platformDict[kSPMobileScale] = deviceInfoMonitor.scale

--- a/Tests/TestPlatformContext.swift
+++ b/Tests/TestPlatformContext.swift
@@ -182,6 +182,17 @@ class TestPlatformContext: XCTestCase {
         XCTAssertNil(platformDict[kSPMobileAppleIdfa])
         XCTAssertNil(platformDict[kSPMobileAppleIdfv])
     }
+    
+    func testTruncatesLanguageToMax8Chars() {
+        let deviceInfoMonitor = MockDeviceInfoMonitor()
+        deviceInfoMonitor.language = "1234567890"
+        let context = PlatformContext(mobileDictUpdateFrequency: 0, networkDictUpdateFrequency: 1, deviceInfoMonitor: deviceInfoMonitor)
+        let platformDict = context.fetchPlatformDict(
+            userAnonymisation: true,
+            advertisingIdentifierRetriever: { UUID() }
+        )
+        XCTAssertEqual("12345678", platformDict[kSPMobileLanguage] as? String)
+    }
 #endif
 
     func testOnlyAddsRequestedProperties() {

--- a/Tests/Utils/MockDeviceInfoMonitor.swift
+++ b/Tests/Utils/MockDeviceInfoMonitor.swift
@@ -109,8 +109,10 @@ class MockDeviceInfoMonitor: DeviceInfoMonitor {
         return 2.0
     }
     
+    private var _language: String? = "EN"
     override var language: String? {
-        return "EN"
+        get { return _language }
+        set { _language = newValue }
     }
 
     func accessCount(_ method: String) -> Int {


### PR DESCRIPTION
Issue #795

This PR handles situations where the language property in the `mobile_context` entity was longer than 8 characters, which caused validation errors as the property has a `maxLength` setting of 8 chars.