### PR TITLE
Fix error while reading v1.7 style install timestamps.

### DIFF
--- a/Sources/Core/Tracker/InstallTracker.swift
+++ b/Sources/Core/Tracker/InstallTracker.swift
@@ -27,7 +27,7 @@ class InstallTracker: NSObject {
             return value as? Date
         } else if value is NSNumber {
             // v1.7 format
-            let timeInterval = TimeInterval((value as? NSNumber)?.doubleValue ?? 0.0 / 1000)
+            let timeInterval = TimeInterval(((value as? NSNumber)?.doubleValue ?? 0.0) / 1000)
             return Date(timeIntervalSince1970: timeInterval)
         }
         return nil


### PR DESCRIPTION
Missing parentheses cause the timestamp to be returned in milliseconds and results in events rejected by the enricher due to incorrect timestamp, for example:

```
$.firstEventTimestamp: 54117-05-18T03:59:14.366Z is an invalid date-time
```