### PR TITLE
Process tracked events on a serial background queue (close #822)

### DIFF
--- a/Sources/Core/Tracker/Tracker.swift
+++ b/Sources/Core/Tracker/Tracker.swift
@@ -41,7 +41,7 @@ class Tracker: NSObject {
     private var platformContextSchema: String = ""
     private var dataCollection = true
     private var builderFinished = false
-    private let eventProcessQueue = DispatchQueueWrapper(label: "snowplow.track")
+    private let eventProcessQueue: DispatchQueueWrapperProtocol
 
     /// The object used for sessionization, i.e. it characterizes user activity.
     private(set) var session: Session?
@@ -287,10 +287,12 @@ class Tracker: NSObject {
     init(trackerNamespace: String,
          appId: String?,
          emitter: Emitter,
+         dispatchQueue: DispatchQueueWrapperProtocol = DispatchQueueWrapper(label: "snowplow.tracker"),
          builder: ((Tracker) -> (Void))) {
         self._emitter = emitter
         self._appId = appId ?? ""
         self._trackerNamespace = trackerNamespace
+        self.eventProcessQueue = dispatchQueue
         
         super.init()
         builder(self)

--- a/Sources/Core/Tracker/Tracker.swift
+++ b/Sources/Core/Tracker/Tracker.swift
@@ -41,8 +41,7 @@ class Tracker: NSObject {
     private var platformContextSchema: String = ""
     private var dataCollection = true
     private var builderFinished = false
-    private let eventProcessQueue = DispatchQueue(label: "snowplow.track")
-
+    private let eventProcessQueue = DispatchQueueWrapper(label: "snowplow.track")
 
     /// The object used for sessionization, i.e. it characterizes user activity.
     private(set) var session: Session?

--- a/Sources/Core/Tracker/Tracker.swift
+++ b/Sources/Core/Tracker/Tracker.swift
@@ -443,9 +443,15 @@ class Tracker: NSObject {
         if !dataCollection {
             return nil
         }
-        event.beginProcessing(withTracker: self)
-        let eventId = processEvent(event)
-        event.endProcessing(withTracker: self)
+        let eventId = DispatchQueue.global(qos: .default).sync {
+            event.beginProcessing(withTracker: self)
+            let eventId = self.processEvent(event)
+//            Thread.sleep(forTimeInterval: 10)
+//            print("❗️ after sleep")
+            event.endProcessing(withTracker: self)
+            return eventId
+        }
+        print("❗️ after queue block")
         return eventId
     }
 

--- a/Sources/Core/Tracker/Tracker.swift
+++ b/Sources/Core/Tracker/Tracker.swift
@@ -40,8 +40,8 @@ func uncaughtExceptionHandler(_ exception: NSException) {
 class Tracker: NSObject {
     private var platformContextSchema: String = ""
     private var dataCollection = true
-
     private var builderFinished = false
+    private let eventProcessQueue = DispatchQueue(label: "snowplow.track")
 
 
     /// The object used for sessionization, i.e. it characterizes user activity.
@@ -444,7 +444,7 @@ class Tracker: NSObject {
             return nil
         }
         let eventId = UUID()
-        DispatchQueue(label: "snowplow.track").async {
+        eventProcessQueue.async {
             event.beginProcessing(withTracker: self)
             self.processEvent(event, eventId)
             event.endProcessing(withTracker: self)

--- a/Sources/Core/Tracker/Tracker.swift
+++ b/Sources/Core/Tracker/Tracker.swift
@@ -174,7 +174,7 @@ class Tracker: NSObject {
             return _deepLinkContext
         }
         set(deepLinkContext) {
-            serialQueue.async {
+            serialQueue.sync {
                 self._deepLinkContext = deepLinkContext
                 if deepLinkContext {
                     self.addOrReplace(stateMachine: DeepLinkStateMachine())
@@ -191,7 +191,7 @@ class Tracker: NSObject {
             return _screenContext
         }
         set(screenContext) {
-            serialQueue.async {
+            serialQueue.sync {
                 self._screenContext = screenContext
                 if screenContext {
                     self.addOrReplace(stateMachine: ScreenStateMachine())
@@ -240,7 +240,7 @@ class Tracker: NSObject {
             return _lifecycleEvents
         }
         set(lifecycleEvents) {
-            serialQueue.async {
+            serialQueue.sync {
                 self._lifecycleEvents = lifecycleEvents
                 if lifecycleEvents {
                     self.addOrReplace(stateMachine: LifecycleStateMachine())
@@ -461,9 +461,9 @@ class Tracker: NSObject {
         if let payload = self.payload(with: trackerEvent) {
             emitter.addPayload(toBuffer: payload)
             stateManager.afterTrack(event: trackerEvent)
-            return
+        } else {
+            logDebug(message: "Event not tracked due to filtering")
         }
-        logDebug(message: "Event not tracked due to filtering")
     }
 
     func payload(with event: TrackerEvent) -> Payload? {

--- a/Sources/Core/Tracker/TrackerEvent.swift
+++ b/Sources/Core/Tracker/TrackerEvent.swift
@@ -39,7 +39,7 @@ class TrackerEvent : InspectableEvent, StateMachineEvent {
     
     private(set) var isService: Bool
     
-    init(event: Event, eventId: UUID, state: TrackerStateSnapshot? = nil) {
+    init(event: Event, eventId: UUID = UUID(), state: TrackerStateSnapshot? = nil) {
         self.eventId = eventId
         timestamp = Int64(Date().timeIntervalSince1970 * 1000)
         trueTimestamp = event.trueTimestamp

--- a/Sources/Core/Tracker/TrackerEvent.swift
+++ b/Sources/Core/Tracker/TrackerEvent.swift
@@ -39,8 +39,8 @@ class TrackerEvent : InspectableEvent, StateMachineEvent {
     
     private(set) var isService: Bool
     
-    init(event: Event, state: TrackerStateSnapshot? = nil) {
-        eventId = UUID()
+    init(event: Event, eventId: UUID, state: TrackerStateSnapshot? = nil) {
+        self.eventId = eventId
         timestamp = Int64(Date().timeIntervalSince1970 * 1000)
         trueTimestamp = event.trueTimestamp
         entities = event.entities

--- a/Sources/Core/Utils/DispatchQueueWrapper.swift
+++ b/Sources/Core/Utils/DispatchQueueWrapper.swift
@@ -20,6 +20,10 @@ class DispatchQueueWrapper: DispatchQueueWrapperProtocol {
         queue = DispatchQueue(label: label)
     }
     
+    func sync(_ callback: @escaping () -> Void) {
+        queue.sync(execute: callback)
+    }
+    
     func async(_ callback: @escaping () -> Void) {
         queue.async(execute: callback)
     }

--- a/Sources/Core/Utils/DispatchQueueWrapper.swift
+++ b/Sources/Core/Utils/DispatchQueueWrapper.swift
@@ -1,0 +1,26 @@
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+
+import Foundation
+
+class DispatchQueueWrapper: DispatchQueueWrapperProtocol {
+    private let queue: DispatchQueue
+    
+    init(label: String) {
+        queue = DispatchQueue(label: label)
+    }
+    
+    func async(_ callback: @escaping () -> Void) {
+        queue.async(execute: callback)
+    }
+}

--- a/Sources/Core/Utils/DispatchQueueWrapperProtocol.swift
+++ b/Sources/Core/Utils/DispatchQueueWrapperProtocol.swift
@@ -14,5 +14,6 @@
 import Foundation
 
 protocol DispatchQueueWrapperProtocol: AnyObject {
+    func sync(_ callback: @escaping () -> Void)
     func async(_ callback: @escaping () -> Void)
 }

--- a/Sources/Core/Utils/DispatchQueueWrapperProtocol.swift
+++ b/Sources/Core/Utils/DispatchQueueWrapperProtocol.swift
@@ -1,0 +1,18 @@
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+
+import Foundation
+
+protocol DispatchQueueWrapperProtocol: AnyObject {
+    func async(_ callback: @escaping () -> Void)
+}

--- a/Tests/Configurations/TestTrackerConfiguration.swift
+++ b/Tests/Configurations/TestTrackerConfiguration.swift
@@ -186,8 +186,10 @@ class TestTrackerConfiguration: XCTestCase {
         let tracker = Snowplow.createTracker(namespace: "namespace", network: networkConfig, configurations: [trackerConfig, sessionConfig])
 
         _ = tracker?.track(Timing(category: "cat", variable: "var", timing: 123))
+        Thread.sleep(forTimeInterval: 3)
         tracker?.session?.startNewSession()
         _ = tracker?.track(Timing(category: "cat", variable: "var", timing: 123))
+        Thread.sleep(forTimeInterval: 3)
 
         wait(for: [expectation], timeout: 10)
     }

--- a/Tests/Configurations/TestTrackerConfiguration.swift
+++ b/Tests/Configurations/TestTrackerConfiguration.swift
@@ -186,10 +186,10 @@ class TestTrackerConfiguration: XCTestCase {
         let tracker = Snowplow.createTracker(namespace: "namespace", network: networkConfig, configurations: [trackerConfig, sessionConfig])
 
         _ = tracker?.track(Timing(category: "cat", variable: "var", timing: 123))
-        Thread.sleep(forTimeInterval: 3)
+        Thread.sleep(forTimeInterval: 0.1)
         tracker?.session?.startNewSession()
         _ = tracker?.track(Timing(category: "cat", variable: "var", timing: 123))
-        Thread.sleep(forTimeInterval: 3)
+        Thread.sleep(forTimeInterval: 0.1)
 
         wait(for: [expectation], timeout: 10)
     }

--- a/Tests/Configurations/TestTrackerController.swift
+++ b/Tests/Configurations/TestTrackerController.swift
@@ -50,19 +50,19 @@ class TestTrackerController: XCTestCase {
         tracker?.emitter?.pause()
 
         _ = tracker?.track(Structured(category: "c", action: "a"))
-        Thread.sleep(forTimeInterval: 3)
+        Thread.sleep(forTimeInterval: 0.1)
         let sessionIdBefore = tracker?.session?.sessionId
 
         tracker?.userAnonymisation = true
         _ = tracker?.track(Structured(category: "c", action: "a"))
-        Thread.sleep(forTimeInterval: 3)
+        Thread.sleep(forTimeInterval: 0.1)
         let sessionIdAnonymous = tracker?.session?.sessionId
 
         XCTAssertFalse((sessionIdBefore == sessionIdAnonymous))
 
         tracker?.userAnonymisation = false
         _ = tracker?.track(Structured(category: "c", action: "a"))
-        Thread.sleep(forTimeInterval: 3)
+        Thread.sleep(forTimeInterval: 0.1)
         let sessionIdNotAnonymous = tracker?.session?.sessionId
 
         XCTAssertFalse((sessionIdAnonymous == sessionIdNotAnonymous))

--- a/Tests/Configurations/TestTrackerController.swift
+++ b/Tests/Configurations/TestTrackerController.swift
@@ -50,16 +50,19 @@ class TestTrackerController: XCTestCase {
         tracker?.emitter?.pause()
 
         _ = tracker?.track(Structured(category: "c", action: "a"))
+        Thread.sleep(forTimeInterval: 3)
         let sessionIdBefore = tracker?.session?.sessionId
 
         tracker?.userAnonymisation = true
         _ = tracker?.track(Structured(category: "c", action: "a"))
+        Thread.sleep(forTimeInterval: 3)
         let sessionIdAnonymous = tracker?.session?.sessionId
 
         XCTAssertFalse((sessionIdBefore == sessionIdAnonymous))
 
         tracker?.userAnonymisation = false
         _ = tracker?.track(Structured(category: "c", action: "a"))
+        Thread.sleep(forTimeInterval: 3)
         let sessionIdNotAnonymous = tracker?.session?.sessionId
 
         XCTAssertFalse((sessionIdAnonymous == sessionIdNotAnonymous))

--- a/Tests/TestSession.swift
+++ b/Tests/TestSession.swift
@@ -128,7 +128,7 @@ class TestSession: XCTestCase {
         cleanFile(withNamespace: "t1")
         
         let emitter = Emitter(urlEndpoint: "") { emitter in}
-        let tracker = Tracker(trackerNamespace: "t1", appId: nil, emitter: emitter) { tracker in
+        let tracker = Tracker(trackerNamespace: "t1", appId: nil, emitter: emitter, dispatchQueue: MockDispatchQueueWrapper(label: "test")) { tracker in
             tracker.installEvent = false
             tracker.lifecycleEvents = true
             tracker.sessionContext = true
@@ -269,7 +269,7 @@ class TestSession: XCTestCase {
         cleanFile(withNamespace: "tracker")
         
         let emitter = Emitter(urlEndpoint: "") { emitter in}
-        let tracker = Tracker(trackerNamespace: "tracker", appId: nil, emitter: emitter) { tracker in
+        let tracker = Tracker(trackerNamespace: "tracker", appId: nil, emitter: emitter, dispatchQueue: MockDispatchQueueWrapper(label: "test")) { tracker in
             tracker.lifecycleEvents = true
             tracker.sessionContext = true
             tracker.foregroundTimeout = 100
@@ -300,7 +300,7 @@ class TestSession: XCTestCase {
         cleanFile(withNamespace: "tracker")
         
         let emitter = Emitter(urlEndpoint: "") { emitter in}
-        let tracker = Tracker(trackerNamespace: "tracker", appId: nil, emitter: emitter) { tracker in
+        let tracker = Tracker(trackerNamespace: "tracker", appId: nil, emitter: emitter, dispatchQueue: MockDispatchQueueWrapper(label: "test")) { tracker in
             tracker.lifecycleEvents = true
             tracker.sessionContext = true
             tracker.foregroundTimeout = 100
@@ -345,12 +345,13 @@ class TestSession: XCTestCase {
         cleanFile(withNamespace: "tracker2")
 
         let emitter = Emitter(urlEndpoint: "") { emitter in}
-        let tracker1 = Tracker(trackerNamespace: "tracker1", appId: nil, emitter: emitter) { tracker in
+        let queue2 = MockDispatchQueueWrapper(label: "test2")
+        let tracker1 = Tracker(trackerNamespace: "tracker1", appId: nil, emitter: emitter, dispatchQueue: MockDispatchQueueWrapper(label: "test1")) { tracker in
             tracker.sessionContext = true
             tracker.foregroundTimeout = 10
             tracker.backgroundTimeout = 10
         }
-        let tracker2 = Tracker(trackerNamespace: "tracker2", appId: nil, emitter: emitter) { tracker in
+        let tracker2 = Tracker(trackerNamespace: "tracker2", appId: nil, emitter: emitter, dispatchQueue: queue2) { tracker in
             tracker.sessionContext = true
             tracker.foregroundTimeout = 10
             tracker.backgroundTimeout = 10
@@ -378,7 +379,7 @@ class TestSession: XCTestCase {
         XCTAssertEqual(1, tracker2.session!.state!.sessionIndex - initialValue2) // timed out
 
         //Recreate tracker2
-        let tracker2b = Tracker(trackerNamespace: "tracker2", appId: nil, emitter: emitter) { tracker in
+        let tracker2b = Tracker(trackerNamespace: "tracker2", appId: nil, emitter: emitter, dispatchQueue: queue2) { tracker in
             tracker.sessionContext = true
             tracker.foregroundTimeout = 5
             tracker.backgroundTimeout = 5
@@ -398,7 +399,7 @@ class TestSession: XCTestCase {
         storeAsV3_0(withNamespace: "tracker", eventId: "eventId", sessionId: "sessionId", sessionIndex: 123, userId: "userId")
 
         let emitter = Emitter(urlEndpoint: "") { emitter in}
-        let tracker = Tracker(trackerNamespace: "tracker", appId: nil, emitter: emitter) { tracker in
+        let tracker = Tracker(trackerNamespace: "tracker", appId: nil, emitter: emitter, dispatchQueue: MockDispatchQueueWrapper(label: "test")) { tracker in
             tracker.sessionContext = true
         }
         let event = Structured(category: "c", action: "a")

--- a/Tests/Utils/MockDispatchQueueWrapper.swift
+++ b/Tests/Utils/MockDispatchQueueWrapper.swift
@@ -21,6 +21,10 @@ class MockDispatchQueueWrapper: DispatchQueueWrapperProtocol {
         queue = DispatchQueue(label: label)
     }
     
+    func sync(_ callback: @escaping () -> Void) {
+        queue.sync(execute: callback)
+    }
+    
     func async(_ callback: @escaping () -> Void) {
         // execute synchronously!
         queue.sync(execute: callback)

--- a/Tests/Utils/MockDispatchQueueWrapper.swift
+++ b/Tests/Utils/MockDispatchQueueWrapper.swift
@@ -1,0 +1,29 @@
+//  Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+
+import Foundation
+@testable import SnowplowTracker
+
+class MockDispatchQueueWrapper: DispatchQueueWrapperProtocol {
+    private let queue: DispatchQueue
+    
+    init(label: String) {
+        queue = DispatchQueue(label: label)
+    }
+    
+    func async(_ callback: @escaping () -> Void) {
+        // execute synchronously!
+        print("❗️ I'm in fake async call")
+        queue.sync(execute: callback)
+    }
+}

--- a/Tests/Utils/MockDispatchQueueWrapper.swift
+++ b/Tests/Utils/MockDispatchQueueWrapper.swift
@@ -23,7 +23,6 @@ class MockDispatchQueueWrapper: DispatchQueueWrapperProtocol {
     
     func async(_ callback: @escaping () -> Void) {
         // execute synchronously!
-        print("❗️ I'm in fake async call")
         queue.sync(execute: callback)
     }
 }


### PR DESCRIPTION
Tracked events - `Tracker.track(event)` - are processed into Payloads and stored in memory (`Emitter.addPayload()`). This currently occurs on the main thread, which could cause performance issues.

This change adds a new serial async queue to the Tracker. There is a small change in the meaning of the return value from `Tracker.track(event)`. This method returns `UUID?`: currently, `nil` can be returned either if the tracker is paused, or if the event ended up getting filtered out by a plugin and not tracked. Now, `nil` will only mean that the tracker is paused.