### PR TITLE
Separate test targets for unit and integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        platform: [ios, osx, tvos, watchos]
+        platform: [ios, ios, osx, tvos, watchos]
     steps:
       - uses: actions/checkout@v3
       - name: Lint Podspec
@@ -18,28 +18,39 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - name: "xcodebuild (iOS 15.2, Xcode 13.2.1)"
+          - name: "Integration (iOS 15.2, Xcode 13.2.1)"
             os: macos-12
             xcode-version: "13.2.1"
             sdk: iphonesimulator15.2
             destination: "platform=iOS Simulator,OS=15.2,name=iPhone 13"
-          - name: "xcodebuild (macOS 12.1, Xcode 13.2.1)"
+            target: IntegrationTests
+          - name: "Unit (iOS 15.2, Xcode 13.2.1)"
+            os: macos-12
+            xcode-version: "13.2.1"
+            sdk: iphonesimulator15.2
+            destination: "platform=iOS Simulator,OS=15.2,name=iPhone 13"
+            target: Tests
+          - name: "Unit (macOS 12.1, Xcode 13.2.1)"
             os: macos-12
             xcode-version: "13.2.1"
             sdk: macosx12.1
             destination: "platform=OS X"
-          - name: "xcodebuild (watchOS 8.3, Xcode 13.2.1)"
+            target: Tests
+          - name: "Unit (watchOS 8.3, Xcode 13.2.1)"
             os: macos-12
             xcode-version: "13.2.1"
             sdk: watchos8.3
             destination: "platform=watchOS Simulator,OS=8.3,name=Apple Watch Series 7 - 45mm"
-          - name: "xcodebuild (tvOS 15.2, Xcode 13.2.1)"
+            target: Tests
+          - name: "Unit (tvOS 15.2, Xcode 13.2.1)"
             os: macos-12
             xcode-version: "13.2.1"
             sdk: appletvsimulator15.2
             destination: "platform=tvOS Simulator,OS=15.2,name=Apple TV"
+            target: Tests
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -53,13 +64,15 @@ jobs:
           key: ${{ runner.os }}-micro
 
       - name: Get micro
-        if: steps.cache-micro.outputs.cache-hit != 'true'
+        if: steps.cache-micro.outputs.cache-hit != 'true' && matrix.target == 'IntegrationTests'
         run: curl -o micro.jar -L https://github.com/snowplow-incubator/snowplow-micro/releases/download/micro-1.7.0/snowplow-micro-1.7.0.jar
 
       - name: Run Micro in background
+        if: matrix.target == 'IntegrationTests'
         run: java -jar micro.jar &
 
       - name: Wait on Micro endpoint
+        if: matrix.target == 'IntegrationTests'
         timeout-minutes: 2
         run: while ! nc -z '0.0.0.0' 9090; do sleep 1; done
       # -- Micro --
@@ -73,6 +86,7 @@ jobs:
             -scheme SnowplowTracker \
             -sdk "${{ matrix.sdk }}" \
             -destination "${{ matrix.destination }}" \
+            -only-testing ${{ matrix.target }} \
             clean test | xcpretty
 
   build_objc_demo_app:

--- a/Integrationtests/TestTrackEventsToMicro.swift
+++ b/Integrationtests/TestTrackEventsToMicro.swift
@@ -19,11 +19,14 @@ class TestTrackEventsToMicro: XCTestCase {
     
     override func setUp() {
         super.setUp()
+        
+        let trackerConfig = TrackerConfiguration()
+            .logLevel(.debug)
 
-        tracker = Snowplow.createTracker(namespace: "testMicro",
-                                         network: NetworkConfiguration(endpoint: Micro.endpoint))!
+        tracker = Snowplow.createTracker(namespace: "testMicro-" + UUID().uuidString,
+                                         network: NetworkConfiguration(endpoint: Micro.endpoint),
+                                         configurations: [trackerConfig])!
 
-        Micro.setUpMockerIgnores()
         wait(for: [Micro.reset()], timeout: Micro.timeout)
     }
     

--- a/Integrationtests/Utils/Micro.swift
+++ b/Integrationtests/Utils/Micro.swift
@@ -13,7 +13,6 @@
 
 import Foundation
 import XCTest
-import Mocker
 
 class Micro {
     
@@ -25,14 +24,6 @@ class Micro {
 #else
     static let endpoint = "http://0.0.0.0:9090"
 #endif
-    
-    class func setUpMockerIgnores() {
-        Mocker.ignore(URL(string: "\(endpoint)/micro/good")!)
-        Mocker.ignore(URL(string: "\(endpoint)/micro/reset")!)
-        Mocker.ignore(URL(string: "\(endpoint)/micro/all")!)
-        Mocker.ignore(URL(string: "\(endpoint)/com.snowplowanalytics.snowplow/tp2")!)
-        Mocker.ignore(URL(string: "\(endpoint)/i")!)
-    }
     
     class func reset() -> XCTestExpectation {
         let expectation = XCTestExpectation(description: "Reset Micro")

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,13 @@ let package = Package(
                 "SnowplowTracker",
                 "Mocker"
             ],
-            path: "Tests")
+            path: "Tests"),
+        .testTarget(
+            name: "IntegrationTests",
+            dependencies: [
+                "SnowplowTracker"
+            ],
+            path: "IntegrationTests")
     ]
 )
 #if swift(>=5.6)


### PR DESCRIPTION
This PR aims to improve the flakiness of the integration tests in the following ways:

* Separate out a new testing target for the integration tests and only run it on iOS. It is not necessary to run the integration tests on all platforms and this makes the impact of flaky tests smaller.
* The integration tests are run separately from unit tests. Even in case they fail, it will be contained to that one test run and less tests have to be re-run.
* Don't use the fail-fast strategy on the tests in CI because that cancels any other jobs in case one of them fails. It makes the impact of flaky tests larger.

While these changes don't solve the flakiness, I think they can significantly improve the impact of the flakiness of the tests so that it happens less often and is faster to re-run failed tests.