### PR TITLE
Enable representing self-describing data using Codable structs (close #844)

### DIFF
--- a/Sources/Snowplow/Events/SelfDescribing.swift
+++ b/Sources/Snowplow/Events/SelfDescribing.swift
@@ -27,6 +27,19 @@ public class SelfDescribing: SelfDescribingAbstract {
         self._payload = payload
     }
     
+    /// Creates a self-describing event using data represented as an Encodable struct.
+    /// - Parameters:
+    ///   - schema: A valid schema URI.
+    ///   - data: Data represented using an Encodable struct.
+    /// - Returns: A SelfDescribing event.
+    public convenience init<T: Encodable>(schema: String, data: T) throws {
+        let data = try JSONEncoder().encode(data)
+        let jsonObject = try JSONSerialization.jsonObject(with: data)
+        let dict = jsonObject as! [String: Any]
+        
+        self.init(schema: schema, payload: dict)
+    }
+    
     private var _schema: String
     override var schema: String {
         get { return _schema }

--- a/Sources/Snowplow/Payload/SelfDescribingJson.swift
+++ b/Sources/Snowplow/Payload/SelfDescribingJson.swift
@@ -82,6 +82,19 @@ public class SelfDescribingJson: NSObject {
     public convenience init(schema: String, andSelfDescribingJson data: SelfDescribingJson) {
         self.init(schema: schema, andData: data.dictionary)
     }
+    
+    /// Creates a self-describing JSON using data represented as an Encodable struct.
+    /// - Parameters:
+    ///   - schema: A valid schema URI.
+    ///   - data: Data represented using an Encodable struct.
+    /// - Returns: A SelfDescribingJson.
+    public convenience init<T: Encodable>(schema: String, data: T) throws {
+        let data = try JSONEncoder().encode(data)
+        let jsonObject = try JSONSerialization.jsonObject(with: data)
+        let dict = jsonObject as! [String: Any]
+        
+        self.init(schema: schema, andData: dict)
+    }
 
     /// Sets the data field of the self-describing JSON.
     /// - Parameter data: An SPPayload to be nested into the data.

--- a/Tests/TestEvents.swift
+++ b/Tests/TestEvents.swift
@@ -152,7 +152,7 @@ class TestEvents: XCTestCase {
         XCTAssertEqual("action", event.payload["se_ac"] as? String)
     }
 
-    func testUnstructured() {
+    func testSelfDescribing() {
         var data: [String : Any] = [:]
         data["level"] = 23
         data["score"] = 56473
@@ -162,6 +162,22 @@ class TestEvents: XCTestCase {
         let event = SelfDescribing(eventData: sdj)
         XCTAssertEqual("iglu:com.acme_company/demo_ios_event/jsonschema/1-0-0", event.schema)
         XCTAssertEqual(23, event.payload["level"] as? Int)
+    }
+
+    func testSelfDescribingWithEncodableData() {
+        struct Data: Encodable {
+            var level: Int
+            var score: Int
+        }
+        
+        let data = Data(level: 23, score: 56473)
+        let event = try? SelfDescribing(
+            schema: "iglu:com.acme_company/demo_ios_event/jsonschema/1-0-0",
+            data: data
+        )
+        XCTAssertNotNil(event)
+        XCTAssertEqual("iglu:com.acme_company/demo_ios_event/jsonschema/1-0-0", event?.schema)
+        XCTAssertEqual(23, event?.payload["level"] as? Int)
     }
 
     func testConsentWithdrawn() {

--- a/Tests/TestSelfDescribingJson.swift
+++ b/Tests/TestSelfDescribingJson.swift
@@ -78,7 +78,40 @@ class TestSelfDescribingJson: XCTestCase {
         XCTAssertEqual(NSDictionary(dictionary: expected),
                        NSDictionary(dictionary: sdj.dictionary))
     }
-
+    
+    func testInitWithEncodable() {
+        struct EncodableUserData: Encodable {
+            var firstName: String
+            var lastName: String
+            var nickname: String?
+            var age: Decimal
+            var children: [EncodableUserData]?
+        }
+        
+        let user = EncodableUserData(
+            firstName: "John",
+            lastName: "Doe",
+            age: 32.5,
+            children: [
+                EncodableUserData(firstName: "Emily", lastName: "Doe", age: 1.2)
+            ]
+        )
+        
+        let json = try? SelfDescribingJson(schema: "iglu:acme.com/user/jsonschema/1-0-0", data: user)
+        XCTAssertNotNil(json)
+        XCTAssertEqual(json?.data["firstName"] as? String, "John")
+        XCTAssertEqual(json?.data["lastName"] as? String, "Doe")
+        XCTAssertFalse(json?.data.keys.contains("nickname") ?? false)
+        XCTAssertNotNil(json?.data["children"])
+        XCTAssertEqual((json?.data["children"] as? Array<Any>)?.count, 1)
+        XCTAssertEqual(json?.data["age"] as? Double, 32.5)
+        let children = json?.data["children"] as? Array<Dictionary<String, Any>>
+        XCTAssertEqual(children?.count, 1)
+        XCTAssertEqual(children?[0]["firstName"] as? String, "Emily")
+        XCTAssertEqual(children?[0]["lastName"] as? String, "Doe")
+        XCTAssertEqual(children?[0]["age"] as? Double, 1.2)
+    }
+    
     func testUpdateSchema() {
         let expected: [String : Any] = [
             "schema": "iglu:acme.com/test_event_2/jsonschema/1-0-0",
@@ -161,4 +194,3 @@ class TestSelfDescribingJson: XCTestCase {
                        NSDictionary(dictionary: sdj.dictionary))
     }
 }
-


### PR DESCRIPTION
Issue #844 

This PR adds new initializers to the `SelfDescribing` and `SelfDescribingJson` classes that accept data represented using `Encodable` structs. This alllows users to define the data using typed structs and track that directly instead of using untyped dictionaries.

On the background the initializers convert the structs into dictionaries. Although I originally wanted to keep the whole payload using `Encodable` structs, this turns out to be impossible since we need to represent our context entities as a list of heterogeneous types which is not possible using `Encodable` in Swift. So there is a bit of extra computation in the initializers to convert to the dictionaries, but I think that's an acceptable trade-off.