### PR TITLE
Revise the emitter behaviour

### DIFF
--- a/Sources/Core/Emitter/Emitter.swift
+++ b/Sources/Core/Emitter/Emitter.swift
@@ -276,11 +276,14 @@ class Emitter: EmitterEventProcessing {
     }
 
     /// Insert a Payload object into the buffer to be sent to collector.
-    /// This method will add the payload to the database and flush (send all events).
+    /// This method will add the payload to the database and flush (send all events) when the buffer is full.
     /// - Parameter eventPayload: A Payload containing a completed event to be added into the buffer.
     func addPayload(toBuffer eventPayload: Payload) {
         self.eventStore.addEvent(eventPayload)
-        self.flush()
+        
+        if self.eventStore.count() >= self.bufferOption.rawValue {
+            self.flush()
+        }
     }
 
     /// Empties the buffer of events using the respective HTTP request method.

--- a/Sources/Snowplow/Configurations/EmitterConfiguration.swift
+++ b/Sources/Snowplow/Configurations/EmitterConfiguration.swift
@@ -16,7 +16,7 @@ import Foundation
 @objc(SPEmitterConfigurationProtocol)
 public protocol EmitterConfigurationProtocol: AnyObject {
     /// Sets whether the buffer should send events instantly or after the buffer
-    /// has reached it's limit. By default, this is set to BufferOption Default.
+    /// has reached it's limit. By default, this is set to BufferOption single.
     @objc
     var bufferOption: BufferOption { get set }
     /// Maximum number of events collected from the EventStore to be sent in a request.

--- a/Sources/Snowplow/Emitter/BufferOption.swift
+++ b/Sources/Snowplow/Emitter/BufferOption.swift
@@ -16,14 +16,16 @@ import Foundation
 /// An enum for buffer options.
 @objc(SPBufferOption)
 public enum BufferOption : Int {
-    /// Sends both GET and POST requests with only a single event.  Can cause a spike in
-    /// network traffic if used in correlation with a large amount of events.
+    /// Sends both GET and POST requests with only a single event. 
+    /// This is the default setting.
+    /// Can cause a spike in network traffic if used in correlation with a large amount of events.
     case single = 1
-    /// Sends POST requests in groups of 10 events.  This is the default amount of events too
-    /// package into a POST.  All GET requests will still emit one at a time.
-    case defaultGroup = 10
-    /// Sends POST requests in groups of 25 events.  Useful for situations where many events
-    /// need to be sent.  All GET requests will still emit one at a time.
+    /// Sends POST requests in groups of 10 events.
+    /// All GET requests will still emit one at a time.
+    case smallGroup = 10
+    /// Sends POST requests in groups of 25 events.
+    /// Useful for situations where many events need to be sent.
+    /// All GET requests will still emit one at a time.
     case largeGroup = 25
 }
 
@@ -32,8 +34,12 @@ extension BufferOption {
         switch value {
         case "Single":
             return .single
+        case "SmallGroup":
+            return .smallGroup
         case "DefaultGroup":
-            return .defaultGroup
+            return .smallGroup
+        case "LargeGroup":
+            return .largeGroup
         case "HeavyGroup":
             return .largeGroup
         default:

--- a/Sources/Snowplow/Emitter/EmitterDefaults.swift
+++ b/Sources/Snowplow/Emitter/EmitterDefaults.swift
@@ -16,7 +16,7 @@ import Foundation
 public class EmitterDefaults {
     public private(set) static var httpMethod: HttpMethodOptions = .post
     public private(set) static var httpProtocol: ProtocolOptions = .https
-    public private(set) static var emitRange = 150
+    public private(set) static var emitRange = BufferOption.largeGroup.rawValue
     public private(set) static var emitThreadPoolSize = 15
     public private(set) static var byteLimitGet = 40000
     public private(set) static var byteLimitPost = 40000

--- a/Sources/Snowplow/Emitter/EmitterDefaults.swift
+++ b/Sources/Snowplow/Emitter/EmitterDefaults.swift
@@ -21,6 +21,6 @@ public class EmitterDefaults {
     public private(set) static var byteLimitGet = 40000
     public private(set) static var byteLimitPost = 40000
     public private(set) static var serverAnonymisation = false
-    public private(set) static var bufferOption: BufferOption = .defaultGroup
+    public private(set) static var bufferOption: BufferOption = .single
     public private(set) static var retryFailedRequests = true
 }

--- a/Tests/Utils/MockNetworkConnection.swift
+++ b/Tests/Utils/MockNetworkConnection.swift
@@ -48,4 +48,9 @@ class MockNetworkConnection: NSObject, NetworkConnection {
         previousResults.append(requestResults)
         return requestResults
     }
+    
+    func clear() {
+        previousRequests = []
+        previousResults = []
+    }
 }


### PR DESCRIPTION
This PR contains three changes:

### Flush events only when the buffer is full (#827)

Previously the buffer size configuration didn't work as intended – requests to the collector were initiated right after the event was tracked regardless of the buffer size.

This change fixes that and only makes the request once the buffer size is reached.

### Change default buffer option to single (#849)

As mentioned before, previously the buffer size was effectively equal to 1 (even though we stated it was 10). Fixing the above bug, we would now change the buffer size to 10.

Buffer size 1 is probably a better default for client side trackers to avoid losing events that don't make it to a request before an app is quit/uninstalled. Also the same is used on the JavaScript tracker.

This change sets the default buffer size to 1 (from a user's point of view there won't be a difference compared to previous versions).

### Make network requests serially in network connection (#827)

This change tries to address a problem with duplicate events often showing up in the warehouse. It is possible that this is called by sending too many parallel requests at once which causes either the requests to fail or timeout and then be retried.

After doing some tests, I discovered that making parallel requests from the client has very little benefit. The total time it takes to send all the events is very close to what it would be if requests were made serially.

The new behaviour updates how the `emitRange` configuration is used – it now tells how many events should be added to one request. For this reason, I also lowered the default value to 25.

When merging this PR, I will rebase the commits so that they show up individually in the release branch.