### PR TITLE
Update CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,35 +21,39 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "Integration (iOS 15.2, Xcode 13.2.1)"
+          - name: "Integration (iOS 15.5, Xcode 13.4)"
             os: macos-12
-            xcode-version: "13.2.1"
-            sdk: iphonesimulator15.2
-            destination: "platform=iOS Simulator,OS=15.2,name=iPhone 13"
+            xcode-version: 13.4
+            sdk: iphonesimulator15.5
+            destination: "platform=iOS Simulator,OS=15.5,name=iPhone 13"
             target: IntegrationTests
-          - name: "Unit (iOS 15.2, Xcode 13.2.1)"
+
+          - name: "Unit (iOS 15.5, Xcode 13.4)"
             os: macos-12
-            xcode-version: "13.2.1"
-            sdk: iphonesimulator15.2
-            destination: "platform=iOS Simulator,OS=15.2,name=iPhone 13"
+            xcode-version: 13.4
+            sdk: iphonesimulator15.5
+            destination: "platform=iOS Simulator,OS=15.5,name=iPhone 13"
             target: Tests
-          - name: "Unit (macOS 12.1, Xcode 13.2.1)"
+
+          - name: "Unit (macOS 12.1, Xcode 13.4)"
             os: macos-12
-            xcode-version: "13.2.1"
+            xcode-version: 13.4
             sdk: macosx12.1
             destination: "platform=OS X"
             target: Tests
-          - name: "Unit (watchOS 8.3, Xcode 13.2.1)"
+
+          - name: "Unit (watchOS 8.5, Xcode 13.4)"
             os: macos-12
-            xcode-version: "13.2.1"
-            sdk: watchos8.3
-            destination: "platform=watchOS Simulator,OS=8.3,name=Apple Watch Series 7 - 45mm"
+            xcode-version: 13.4
+            sdk: watchos8.5
+            destination: "platform=watchOS Simulator,OS=8.5,name=Apple Watch Series 7 - 45mm"
             target: Tests
-          - name: "Unit (tvOS 15.2, Xcode 13.2.1)"
+
+          - name: "Unit (tvOS 15.5, Xcode 13.4)"
             os: macos-12
-            xcode-version: "13.2.1"
+            xcode-version: 13.4
             sdk: appletvsimulator15.2
-            destination: "platform=tvOS Simulator,OS=15.2,name=Apple TV"
+            destination: "platform=tvOS Simulator,OS=15.5,name=Apple TV"
             target: Tests
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,14 @@ on: [push]
 jobs:
   podspec:
     name: Lint Podspec for ${{ matrix.platform }}
-    runs-on: macos-11
+    runs-on: macos-latest
     strategy:
       matrix:
         platform: [ios, ios, osx, tvos, watchos]
     steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - uses: actions/checkout@v3
       - name: Lint Podspec
         run: pod lib lint --platforms=${{ matrix.platform }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,39 +24,34 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "Integration (iOS 15.5, Xcode 13.4)"
+          - name: "Integration (iOS, Xcode 13.4)"
             os: macos-12
             xcode-version: 13.4
-            sdk: iphonesimulator15.5
-            destination: "platform=iOS Simulator,OS=15.5,name=iPhone 13"
+            destination: "platform=iOS Simulator,name=iPhone 13"
             target: IntegrationTests
 
-          - name: "Unit (iOS 15.5, Xcode 13.4)"
+          - name: "Unit (iOS, Xcode 13.4)"
             os: macos-12
             xcode-version: 13.4
-            sdk: iphonesimulator15.5
-            destination: "platform=iOS Simulator,OS=15.5,name=iPhone 13"
+            destination: "platform=iOS Simulator,name=iPhone 13"
             target: Tests
 
-          - name: "Unit (macOS 12.1, Xcode 13.4)"
+          - name: "Unit (macOS, Xcode 13.4)"
             os: macos-12
             xcode-version: 13.4
-            sdk: macosx12.1
-            destination: "platform=OS X"
+            destination: "platform=macOS"
             target: Tests
 
-          - name: "Unit (watchOS 8.5, Xcode 13.4)"
+          - name: "Unit (watchOS, Xcode 13.4)"
             os: macos-12
             xcode-version: 13.4
-            sdk: watchos8.5
-            destination: "platform=watchOS Simulator,OS=8.5,name=Apple Watch Series 7 - 45mm"
+            destination: "platform=watchOS Simulator,name=Apple Watch Series 7 - 45mm"
             target: Tests
 
-          - name: "Unit (tvOS 15.5, Xcode 13.4)"
+          - name: "Unit (tvOS, Xcode 13.4)"
             os: macos-12
             xcode-version: 13.4
-            sdk: appletvsimulator15.2
-            destination: "platform=tvOS Simulator,OS=15.5,name=Apple TV"
+            destination: "platform=tvOS Simulator,name=Apple TV"
             target: Tests
     steps:
       - name: Checkout
@@ -84,14 +79,14 @@ jobs:
         run: while ! nc -z '0.0.0.0' 9090; do sleep 1; done
       # -- Micro --
 
-      - name: Select Xcode Version
-        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.xcode-version }}
 
       - name: Build & Test
         run: |
           set -o pipefail && xcodebuild \
             -scheme SnowplowTracker \
-            -sdk "${{ matrix.sdk }}" \
             -destination "${{ matrix.destination }}" \
             -only-testing ${{ matrix.target }} \
             -resultBundlePath TestResults \

--- a/Sources/Core/RemoteConfiguration/RemoteConfigurationCache.swift
+++ b/Sources/Core/RemoteConfiguration/RemoteConfigurationCache.swift
@@ -68,7 +68,23 @@ class RemoteConfigurationCache: NSObject {
                   let data = try? Data(contentsOf: cacheFileUrl) else { return }
             if #available(iOS 12, tvOS 12, watchOS 5, macOS 10.14, *) {
                 do {
-                    configuration = try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data) as? RemoteConfigurationBundle
+                    configuration = try NSKeyedUnarchiver.unarchivedObject(
+                        ofClasses: [
+                            ConfigurationBundle.self,
+                            RemoteConfigurationBundle.self,
+                            NetworkConfiguration.self,
+                            TrackerConfiguration.self,
+                            SubjectConfiguration.self,
+                            SessionConfiguration.self,
+                            EmitterConfiguration.self,
+                            SPSize.self,
+                            NSString.self,
+                            NSArray.self,
+                            NSDictionary.self,
+                            NSNumber.self
+                        ],
+                        from: data
+                    ) as? RemoteConfigurationBundle
                 } catch let error {
                     logError(message: String(format: "Exception on getting configuration from cache: %@", error.localizedDescription))
                     configuration = nil


### PR DESCRIPTION
Simplifies the github build action so that it doesn't specify the OS versions – only the XCode version is specified for the unit and integration tests.

Also updates the lint action to use the latest XCode version.

Finally, use of a deprecated API (`NSKeyedUnarchiver.unarchiveTopLevelObjectWithData`) is replaced with the recommended one to avoid build failures.