### PR TITLE
Fix bundle path check to handle symbolic links (close #858)

### DIFF
--- a/Sources/Core/ScreenViewTracking/UIKitScreenViewTracking.swift
+++ b/Sources/Core/ScreenViewTracking/UIKitScreenViewTracking.swift
@@ -69,9 +69,15 @@ extension UIViewController {
     @objc func sp_viewDidAppear(_ animated: Bool) {
         sp_viewDidAppear(animated)
 
-        let bundle = Bundle(for: self.classForCoder)
-        if !bundle.bundlePath.hasPrefix(Bundle.main.bundlePath) {
-            // Ignore view controllers that don't start with the main bundle path
+        let bundleURL = Bundle(for: self.classForCoder).bundleURL
+        let mainBundleURL = Bundle.main.bundleURL
+
+        // Resolve any symbolic links and standardize the file paths
+        let resolvedBundlePath = bundleURL.resolvingSymlinksInPath().path
+        let resolvedMainBundlePath = mainBundleURL.resolvingSymlinksInPath().path
+        
+        // Ignore view controllers that don't start with the main bundle path
+        guard resolvedBundlePath.hasPrefix(resolvedMainBundlePath) else {
             return
         }
         
@@ -81,7 +87,7 @@ extension UIViewController {
         // Construct userInfo
         var userInfo: [AnyHashable : Any] = [:]
         userInfo["viewControllerClassName"] = String(describing: self.classForCoder)
-        userInfo["topViewControllerClassName"] = String(describing: top.self.classForCoder)
+        userInfo["topViewControllerClassName"] = String(describing: top.classForCoder)
         
         // `name` is set to snowplowId class instance variable if it exists (hence no @"id" in userInfo)
         userInfo["name"] = _SP_getName(self) ?? _SP_getName(top) ?? "Unknown"


### PR DESCRIPTION
This PR addresses issue [#858](https://github.com/snowplow/snowplow-ios-tracker/issues/858) concerning the Snowplow SDK's bundle path handling in modularized iOS apps. The current `UIViewController` extension's method for tracking screen views fails on real iOS devices due to not accounting for the symbolic link between `/private/var/` and `/var/`.

The fix involves updating `sp_viewDidAppear` to use `resolvingSymlinksInPath()`, ensuring the bundle paths for both the main app and its frameworks are standardized. This method resolves `/private/var/` to `/var/`, aligning framework paths with the main app bundle. This change guarantees accurate tracking of view controllers across all frameworks on iOS devices.