### PR TITLE
Add configurable limit for the maximum age and number of events in the event store and remove old events before sending (close #860)

### DIFF
--- a/Sources/Core/Emitter/Emitter.swift
+++ b/Sources/Core/Emitter/Emitter.swift
@@ -197,6 +197,12 @@ class Emitter: EmitterEventProcessing {
         return Int(eventStore.count())
     }
     
+    /// Limit for the maximum number of unsent events to keep in the event store.
+    var maxEventStoreSize: Int64 = EmitterDefaults.maxEventStoreSize
+    
+    /// Limit for the maximum duration of how long events should be kept in the event store if they fail to be sent.
+    var maxEventStoreAge: TimeInterval = EmitterDefaults.maxEventStoreAge
+    
     // MARK: - Initialization
     
     init(namespace: String,
@@ -289,11 +295,19 @@ class Emitter: EmitterEventProcessing {
     /// Empties the buffer of events using the respective HTTP request method.
     func flush() {
         if requestToStartSending() {
+            self.removeOldEvents()
             self.attemptEmit()
         }
     }
 
     // MARK: - Control methods
+    
+    private func removeOldEvents() {
+        eventStore.removeOldEvents(
+            maxSize: maxEventStoreSize,
+            maxAge: maxEventStoreAge
+        )
+    }
 
     private func attemptEmit() {
         InternalQueue.onQueuePrecondition()

--- a/Sources/Core/Emitter/EmitterControllerImpl.swift
+++ b/Sources/Core/Emitter/EmitterControllerImpl.swift
@@ -115,6 +115,22 @@ class EmitterControllerImpl: Controller, EmitterController {
             emitter.retryFailedRequests = newValue
         }
     }
+    
+    var maxEventStoreSize: Int64 {
+        get { return emitter.maxEventStoreSize }
+        set {
+            dirtyConfig.maxEventStoreSize = newValue
+            emitter.maxEventStoreSize = newValue
+        }
+    }
+    
+    var maxEventStoreAge: TimeInterval {
+        get { return emitter.maxEventStoreAge }
+        set {
+            dirtyConfig.maxEventStoreAge = newValue
+            emitter.maxEventStoreAge = newValue
+        }
+    }
 
     // MARK: - Methods
 

--- a/Sources/Core/InternalQueue/EmitterControllerIQWrapper.swift
+++ b/Sources/Core/InternalQueue/EmitterControllerIQWrapper.swift
@@ -75,6 +75,16 @@ class EmitterControllerIQWrapper: EmitterController {
         get { return InternalQueue.sync { controller.retryFailedRequests } }
         set { InternalQueue.sync { controller.retryFailedRequests = newValue } }
     }
+    
+    var maxEventStoreSize: Int64 {
+        get { return InternalQueue.sync { controller.maxEventStoreSize } }
+        set { InternalQueue.sync { controller.maxEventStoreSize = newValue } }
+    }
+    
+    var maxEventStoreAge: TimeInterval {
+        get { return InternalQueue.sync { controller.maxEventStoreAge } }
+        set { InternalQueue.sync { controller.maxEventStoreAge = newValue } }
+    }
 
     // MARK: - Methods
 

--- a/Sources/Core/Storage/Database.swift
+++ b/Sources/Core/Storage/Database.swift
@@ -124,6 +124,20 @@ class Database {
         return rows
     }
     
+    func removeOldEvents(maxSize: Int64, maxAge: TimeInterval) {
+        let sql = """
+            DELETE FROM 'events'
+            WHERE id NOT IN (
+                SELECT id FROM events
+                WHERE dateCreated >= datetime('now','-\(maxAge) seconds')
+                ORDER BY dateCreated DESC, id DESC
+                LIMIT \(maxSize)
+            )
+            """
+        
+        _ = execute(sql: sql, name: "Delete old events")
+    }
+    
     private func prepare(sql: String, name: String, closure: (OpaquePointer?, OpaquePointer?) -> ()) {
         withConnection { db in
             var statement: OpaquePointer?

--- a/Sources/Core/Storage/SQLiteEventStore.swift
+++ b/Sources/Core/Storage/SQLiteEventStore.swift
@@ -79,6 +79,12 @@ class SQLiteEventStore: NSObject, EventStore {
             return EmitterEvent(payload: payload, storeId: row.id)
         }
     }
+    
+    func removeOldEvents(maxSize: Int64, maxAge: TimeInterval) {
+        InternalQueue.onQueuePrecondition()
+        
+        return database.removeOldEvents(maxSize: maxSize, maxAge: maxAge)
+    }
 }
 
 #endif

--- a/Sources/Core/Tracker/ServiceProvider.swift
+++ b/Sources/Core/Tracker/ServiceProvider.swift
@@ -241,6 +241,8 @@ class ServiceProvider: NSObject, ServiceProviderProtocol {
             emitter.callback = self.emitterConfiguration.requestCallback
             emitter.customRetryForStatusCodes = self.emitterConfiguration.customRetryForStatusCodes
             emitter.retryFailedRequests = self.emitterConfiguration.retryFailedRequests
+            emitter.maxEventStoreSize = self.emitterConfiguration.maxEventStoreSize
+            emitter.maxEventStoreAge = self.emitterConfiguration.maxEventStoreAge
         }
 
         let emitter: Emitter

--- a/Sources/Snowplow/Configurations/EmitterConfiguration.swift
+++ b/Sources/Snowplow/Configurations/EmitterConfiguration.swift
@@ -45,6 +45,14 @@ public protocol EmitterConfigurationProtocol: AnyObject {
     /// If disabled, events that failed to be sent will be dropped regardless of other configuration (such as the customRetryForStatusCodes).
     @objc
     var retryFailedRequests: Bool { get set }
+    /// Limit for the maximum number of unsent events to keep in the event store.
+    /// Defaults to 1000.
+    @objc
+    var maxEventStoreSize: Int64 { get set }
+    /// Limit for the maximum duration of how long events should be kept in the event store if they fail to be sent.
+    /// Defaults to 30 days.
+    @objc
+    var maxEventStoreAge: TimeInterval { get set }
 }
 
 /// It allows the tracker configuration from the emission perspective.
@@ -134,6 +142,24 @@ public class EmitterConfiguration: SerializableConfiguration, EmitterConfigurati
     public var retryFailedRequests: Bool {
         get { return _retryFailedRequests ?? sourceConfig?.retryFailedRequests ?? EmitterDefaults.retryFailedRequests }
         set { _retryFailedRequests = newValue }
+    }
+    
+    private var _maxEventStoreSize: Int64?
+    /// Limit for the maximum number of unsent events to keep in the event store.
+    /// Defaults to 1000.
+    @objc
+    public var maxEventStoreSize: Int64 {
+        get { return _maxEventStoreSize ?? sourceConfig?.maxEventStoreSize ?? EmitterDefaults.maxEventStoreSize }
+        set { _maxEventStoreSize = newValue }
+    }
+    
+    private var _maxEventStoreAge: TimeInterval?
+    /// Limit for the maximum duration of how long events should be kept in the event store if they fail to be sent.
+    /// Defaults to 30 days.
+    @objc
+    public var maxEventStoreAge: TimeInterval {
+        get { return _maxEventStoreAge ?? sourceConfig?.maxEventStoreAge ?? EmitterDefaults.maxEventStoreAge }
+        set { _maxEventStoreAge = newValue }
     }
     
     // MARK: - Internal
@@ -255,6 +281,22 @@ public class EmitterConfiguration: SerializableConfiguration, EmitterConfigurati
     @objc
     public func retryFailedRequests(_ retryFailedRequests: Bool) -> Self {
         self.retryFailedRequests = retryFailedRequests
+        return self
+    }
+    
+    /// Limit for the maximum number of unsent events to keep in the event store.
+    /// Defaults to 1000.
+    @objc
+    public func maxEventStoreSize(_ maxEventStoreSize: Int64) -> Self {
+        self.maxEventStoreSize = maxEventStoreSize
+        return self
+    }
+    
+    /// Limit for the maximum duration of how long events should be kept in the event store if they fail to be sent.
+    /// Defaults to 30 days.
+    @objc
+    public func maxEventStoreAge(_ maxEventStoreAge: TimeInterval) -> Self {
+        self.maxEventStoreAge = maxEventStoreAge
         return self
     }
     

--- a/Sources/Snowplow/Configurations/EmitterConfiguration.swift
+++ b/Sources/Snowplow/Configurations/EmitterConfiguration.swift
@@ -315,6 +315,8 @@ public class EmitterConfiguration: SerializableConfiguration, EmitterConfigurati
         copy.serverAnonymisation = serverAnonymisation
         copy.eventStore = eventStore
         copy.retryFailedRequests = retryFailedRequests
+        copy.maxEventStoreAge = maxEventStoreAge
+        copy.maxEventStoreSize = maxEventStoreSize
         return copy
     }
 
@@ -333,6 +335,8 @@ public class EmitterConfiguration: SerializableConfiguration, EmitterConfigurati
         coder.encode(customRetryForStatusCodes, forKey: "customRetryForStatusCodes")
         coder.encode(serverAnonymisation, forKey: "serverAnonymisation")
         coder.encode(retryFailedRequests, forKey: "retryFailedRequests")
+        coder.encode(maxEventStoreAge, forKey: "maxEventStoreAge")
+        coder.encode(maxEventStoreSize, forKey: "maxEventStoreSize")
     }
 
     required init?(coder: NSCoder) {
@@ -350,6 +354,12 @@ public class EmitterConfiguration: SerializableConfiguration, EmitterConfigurati
         serverAnonymisation = coder.decodeBool(forKey: "serverAnonymisation")
         if coder.containsValue(forKey: "retryFailedRequests") {
             retryFailedRequests = coder.decodeBool(forKey: "retryFailedRequests")
+        }
+        if coder.containsValue(forKey: "maxEventStoreAge") {
+            maxEventStoreAge = coder.decodeDouble(forKey: "maxEventStoreAge")
+        }
+        if coder.containsValue(forKey: "maxEventStoreSize") {
+            maxEventStoreSize = coder.decodeInt64(forKey: "maxEventStoreSize")
         }
     }
 }

--- a/Sources/Snowplow/Emitter/EmitterDefaults.swift
+++ b/Sources/Snowplow/Emitter/EmitterDefaults.swift
@@ -23,4 +23,6 @@ public class EmitterDefaults {
     public private(set) static var serverAnonymisation = false
     public private(set) static var bufferOption: BufferOption = .single
     public private(set) static var retryFailedRequests = true
+    public private(set) static var maxEventStoreSize: Int64 = 1000 // events
+    public private(set) static var maxEventStoreAge: TimeInterval = TimeInterval(60 * 60 * 24 * 30) // 30 days
 }

--- a/Sources/Snowplow/Emitter/EventStore.swift
+++ b/Sources/Snowplow/Emitter/EventStore.swift
@@ -43,4 +43,10 @@ public protocol EventStore: NSObjectProtocol {
     /// - Returns: EmitterEvent objects containing storeIds and event payloads.
     @objc
     func emittableEvents(withQueryLimit queryLimit: UInt) -> [EmitterEvent]
+    /// Remove events older than `maxAge` seconds and keep only the latest `maxSize` events.
+    /// - Parameters:
+    ///   - maxSize: Limit for the maximum number of unsent events to keep
+    ///   - maxAge: Limit for the maximum duration of how long events should be kept
+    @objc
+    func removeOldEvents(maxSize: Int64, maxAge: TimeInterval)
 }

--- a/Tests/Storage/TestDatabase.swift
+++ b/Tests/Storage/TestDatabase.swift
@@ -111,6 +111,38 @@ class TestDatabase: XCTestCase {
         XCTAssertEqual(db.countRows(), 0)
     }
     
+    func testRemoveOldEventsByAge() {
+        let db = createDatabase("db")
+        
+        db.insertRow(["test": 1])
+        Thread.sleep(forTimeInterval: 1)
+        db.insertRow(["test": 2])
+        Thread.sleep(forTimeInterval: 1)
+        db.removeOldEvents(maxSize: 5, maxAge: 1)
+        
+        let rows = db.readRows(numRows: 5)
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows.first?.data["test"] as? Int, 2)
+    }
+    
+    func testRemoveOldestEventsByMaxSize() {
+        let db = createDatabase("db")
+        
+        db.insertRow(["test": 1])
+        db.insertRow(["test": 2])
+        db.insertRow(["test": 3])
+        db.insertRow(["test": 4])
+        db.insertRow(["test": 5])
+        db.removeOldEvents(maxSize: 3, maxAge: 5)
+        
+        let rows = db.readRows(numRows: 5)
+        XCTAssertEqual(rows.count, 3)
+        XCTAssertEqual(
+            rows.map { $0.data["test"] as! Int }.min(),
+            3
+        )
+    }
+    
     private func createDatabase(_ namespace: String) -> Database {
         DatabaseHelpers.clearPreviousDatabase(namespace)
         return Database(namespace: namespace)

--- a/Tests/Storage/TestDatabase.swift
+++ b/Tests/Storage/TestDatabase.swift
@@ -114,25 +114,32 @@ class TestDatabase: XCTestCase {
     func testRemoveOldEventsByAge() {
         let db = createDatabase("db")
         
-        db.insertRow(["test": 1])
-        Thread.sleep(forTimeInterval: 1)
-        db.insertRow(["test": 2])
-        Thread.sleep(forTimeInterval: 1)
+        for i in 1...5 {
+            db.insertRow(["test": i])
+        }
+        
+        Thread.sleep(forTimeInterval: 2)
+        
+        for i in 6...10 {
+            db.insertRow(["test": i])
+        }
+        
         db.removeOldEvents(maxSize: 5, maxAge: 1)
         
-        let rows = db.readRows(numRows: 5)
-        XCTAssertEqual(rows.count, 1)
-        XCTAssertEqual(rows.first?.data["test"] as? Int, 2)
+        let rows = db.readRows(numRows: 10)
+        XCTAssertEqual(rows.count, 5)
+        XCTAssertEqual(
+            rows.map { $0.data["test"] as! Int }.min(),
+            6
+        )
     }
     
     func testRemoveOldestEventsByMaxSize() {
         let db = createDatabase("db")
         
-        db.insertRow(["test": 1])
-        db.insertRow(["test": 2])
-        db.insertRow(["test": 3])
-        db.insertRow(["test": 4])
-        db.insertRow(["test": 5])
+        for i in 1...5 {
+            db.insertRow(["test": i])
+        }
         db.removeOldEvents(maxSize: 3, maxAge: 5)
         
         let rows = db.readRows(numRows: 5)

--- a/Tests/Storage/TestDatabase.swift
+++ b/Tests/Storage/TestDatabase.swift
@@ -124,7 +124,7 @@ class TestDatabase: XCTestCase {
             db.insertRow(["test": i])
         }
         
-        db.removeOldEvents(maxSize: 5, maxAge: 1)
+        db.removeOldEvents(maxSize: 10, maxAge: 1)
         
         let rows = db.readRows(numRows: 10)
         XCTAssertEqual(rows.count, 5)

--- a/Tests/Utils/MockEventStore.swift
+++ b/Tests/Utils/MockEventStore.swift
@@ -69,4 +69,8 @@ class MockEventStore: NSObject, EventStore {
         logVerbose(message: "emittableEventsWithQueryLimit: \(eventIds)")
         return events
     }
+    
+    func removeOldEvents(maxSize: Int64, maxAge: TimeInterval) {
+        // Not implemented in the mock event store.
+    }
 }


### PR DESCRIPTION
Issue #860 

The event store is currently unbounded meaning that if events fail to be sent to the collector, they are never removed from the event store. This can lead to it growing endlessly (if for instance an ad blocker blocks the collector domain) which is likely to have an impact on the app.

We should add configurable limits to the event store so that old events are removed. We could have two such limits:

* maximum event store size – in case the number of events surpasses this threshold, oldest events will be removed until we are under the threshold. Default could be 1000.
* maximum event age – in case there are events older than this threshold, we should remove them. Default could be 30 days.

The implementation in this PR adds these limits and enforces them before each emit attempt. They are enforced by running a single SQL statement which should be relatively efficient.