### PR TITLE
Match BaseEvent entities API with Android tracker

### DIFF
--- a/Sources/Snowplow/Events/EventBase.swift
+++ b/Sources/Snowplow/Events/EventBase.swift
@@ -13,7 +13,7 @@
 
 import Foundation
 
-/// This class has the basic functionality needed to represent all events
+/// This class has the basic functionality needed to represent all events.
 @objc(SPEvent)
 public class Event: NSObject {
     /// The user event timestamp in milliseconds (epoch time).
@@ -82,19 +82,18 @@ public class Event: NSObject {
         return self
     }
     
-    /// Replace the context entities attached to the event with a new list of entities.
+    /// Adds a list of context entities to the existing ones.
     @objc
     public func entities(_ entities: [SelfDescribingJson]) -> Self {
-        self.entities = entities
+        self._entities.append(contentsOf: entities)
         return self
     }
     
-    /// Replace the context entities attached to the event with a new list of entities.
+    /// Adds a list of context entities to the existing ones.
     @objc
     @available(*, deprecated, renamed: "entities")
     public func contexts(_ entities: [SelfDescribingJson]) -> Self {
-        self.entities = entities
-        return self
+        return self.entities(entities)
     }
 }
 

--- a/Tests/TestEvents.swift
+++ b/Tests/TestEvents.swift
@@ -25,6 +25,27 @@ class TestEvents: XCTestCase {
         XCTAssertEqual(event.trueTimestamp, testDate)
     }
 
+    func testEntities() {
+        let event = ScreenView(name: "screen")
+        let entity1 = SelfDescribingJson(schema: "schema1", andData: [String:NSObject]())
+        let entity2 = SelfDescribingJson(schema: "schema2", andData: [String:NSObject]())
+        let entity3 = SelfDescribingJson(schema: "schema3", andData: [String:NSObject]())
+        
+        event.entities.append(entity1)
+        XCTAssertEqual(1, event.entities.count)
+        
+        _ = event.entities([entity2])
+        XCTAssertEqual(2, event.entities.count)
+
+        _ = event.contexts([entity3])
+        XCTAssertEqual(3, event.entities.count)
+        
+        XCTAssertEqual(3, event.contexts.count)
+        XCTAssertTrue(event.entities.contains(entity1))
+        XCTAssertTrue(event.entities.contains(entity2))
+        XCTAssertTrue(event.entities.contains(entity3))
+    }
+
     func testApplicationInstall() {
         // Prepare ApplicationInstall event
         let installEvent = SelfDescribingJson(schema: kSPApplicationInstallSchema, andDictionary: [String:NSObject]())


### PR DESCRIPTION
Breaking changes in the `BaseEvent` class, to standardise the API with the Android tracker.

The `BaseEvent.entities()` builder method now appends the new list of entities, rather than replacing it.