### PR TITLE
Add request timeout to network connection and configuration (close #836)

### DIFF
--- a/Sources/Core/Emitter/Emitter.swift
+++ b/Sources/Core/Emitter/Emitter.swift
@@ -213,6 +213,7 @@ class Emitter: EmitterEventProcessing {
          requestHeaders: [String: String]? = nil,
          serverAnonymisation: Bool? = nil,
          eventStore: EventStore? = nil,
+         timeout: TimeInterval = EmitterDefaults.emitTimeout,
          builder: ((Emitter) -> (Void))? = nil) {
         self.namespace = namespace
         self.eventStore = eventStore ?? Emitter.defaultEventStore(namespace: namespace)
@@ -220,7 +221,8 @@ class Emitter: EmitterEventProcessing {
         let defaultNetworkConnection = DefaultNetworkConnection(
             urlString: urlEndpoint,
             httpMethod: method ?? EmitterDefaults.httpMethod,
-            customPostPath: customPostPath
+            customPostPath: customPostPath,
+            timeout: timeout
         )
         defaultNetworkConnection.requestHeaders = requestHeaders
         defaultNetworkConnection.serverAnonymisation = serverAnonymisation ?? EmitterDefaults.serverAnonymisation

--- a/Sources/Core/Tracker/ServiceProvider.swift
+++ b/Sources/Core/Tracker/ServiceProvider.swift
@@ -264,6 +264,7 @@ class ServiceProvider: NSObject, ServiceProviderProtocol {
                 requestHeaders: self.networkConfiguration.requestHeaders,
                 serverAnonymisation: self.emitterConfiguration.serverAnonymisation,
                 eventStore: self.emitterConfiguration.eventStore,
+                timeout: self.networkConfiguration.timeout,
                 builder: builder
             )
         }

--- a/Sources/Snowplow/Configurations/NetworkConfiguration.swift
+++ b/Sources/Snowplow/Configurations/NetworkConfiguration.swift
@@ -65,12 +65,18 @@ public class NetworkConfiguration: SerializableConfiguration, ConfigurationProto
         set { _requestHeaders = newValue }
     }
     
+    private var _timeout: TimeInterval?
+    /// The maximum timeout for emitting events to the collector.
+    /// Defaults to 30 seconds.
+    @objc var timeout: TimeInterval {
+        get { return _timeout ?? sourceConfig?.timeout ?? EmitterDefaults.emitTimeout }
+        set { _timeout = newValue }
+    }
+    
     // MARK: - Internal
     
     /// Fallback configuration to read from in case requested values are not present in this configuraiton.
     internal var sourceConfig: NetworkConfiguration?
-
-    // TODO: add -> @property () NSInteger timeout;
     
     internal override init() {
     }
@@ -132,6 +138,14 @@ public class NetworkConfiguration: SerializableConfiguration, ConfigurationProto
         self.requestHeaders = headers
         return self
     }
+    
+    /// The maximum timeout for emitting events to the collector.
+    /// Defaults to 30 seconds.
+    @objc
+    public func timeout(_ timeout: TimeInterval) -> Self {
+        self.timeout = timeout
+        return self
+    }
 
     // MARK: - NSCopying
 
@@ -144,6 +158,7 @@ public class NetworkConfiguration: SerializableConfiguration, ConfigurationProto
             copy = NetworkConfiguration(endpoint: endpoint ?? "", method: method )
         }
         copy?.customPostPath = customPostPath
+        copy?.timeout = timeout
         return copy!
     }
 
@@ -159,6 +174,7 @@ public class NetworkConfiguration: SerializableConfiguration, ConfigurationProto
         coder.encode(method.rawValue, forKey: "method")
         coder.encode(customPostPath, forKey: "customPostPath")
         coder.encode(requestHeaders, forKey: "requestHeaders")
+        coder.encode(timeout, forKey: "timeout")
     }
 
     required init?(coder: NSCoder) {
@@ -167,5 +183,6 @@ public class NetworkConfiguration: SerializableConfiguration, ConfigurationProto
         _method = HttpMethodOptions(rawValue: coder.decodeInteger(forKey: "method"))
         _customPostPath = coder.decodeObject(forKey: "customPostPath") as? String
         _requestHeaders = coder.decodeObject(forKey: "requestHeaders") as? [String : String]
+        _timeout = coder.decodeObject(forKey: "timeout") as? TimeInterval
     }
 }

--- a/Sources/Snowplow/Emitter/EmitterDefaults.swift
+++ b/Sources/Snowplow/Emitter/EmitterDefaults.swift
@@ -25,4 +25,5 @@ public class EmitterDefaults {
     public private(set) static var retryFailedRequests = true
     public private(set) static var maxEventStoreSize: Int64 = 1000 // events
     public private(set) static var maxEventStoreAge: TimeInterval = TimeInterval(60 * 60 * 24 * 30) // 30 days
+    public private(set) static var emitTimeout: TimeInterval = TimeInterval(30) // 30 seconds
 }

--- a/Sources/Snowplow/Network/DefaultNetworkConnection.swift
+++ b/Sources/Snowplow/Network/DefaultNetworkConnection.swift
@@ -78,17 +78,39 @@ public class DefaultNetworkConnection: NSObject, NetworkConnection {
     @objc
     public var serverAnonymisation = false
     private var dataOperationQueue = OperationQueue()
+    /// Custom timeout for the requests
+    @objc
+    public var timeout: TimeInterval
+    
+    private var protocolClasses: [AnyClass]?
+    private var _urlSession: URLSession?
+    private var urlSession: URLSession {
+        if let urlSession = _urlSession { return urlSession }
+        
+        let sessionConfig: URLSessionConfiguration = .default
+        sessionConfig.timeoutIntervalForRequest = TimeInterval(self.timeout)
+        sessionConfig.timeoutIntervalForResource = TimeInterval(self.timeout)
+        sessionConfig.protocolClasses = protocolClasses
+        
+        let urlSession = URLSession(configuration: sessionConfig)
+        self._urlSession = urlSession
+        return urlSession
+    }
     
     @objc
     public init(urlString: String,
                 httpMethod: HttpMethodOptions = EmitterDefaults.httpMethod,
                 protocol: ProtocolOptions = EmitterDefaults.httpProtocol,
-                customPostPath: String? = nil) {
+                customPostPath: String? = nil,
+                timeout: TimeInterval = 60,
+                protocolClasses: [AnyClass]? = nil) {
         self._urlString = urlString
+        self.timeout = timeout
         super.init()
         self._httpMethod = httpMethod
         self._protocol = `protocol`
         self._customPostPath = customPostPath
+        self.protocolClasses = protocolClasses
         setup()
     }
 
@@ -97,14 +119,15 @@ public class DefaultNetworkConnection: NSObject, NetworkConnection {
     @objc
     public func sendRequests(_ requests: [Request]) -> [RequestResult] {
         let urlRequests = requests.map { _httpMethod == .get ? buildGet($0) : buildPost($0) }
-        
+
         var results: [RequestResult] = []
         // if there is only one request, make it directly
         if requests.count == 1 {
             if let request = requests.first, let urlRequest = urlRequests.first {
                 let result = DefaultNetworkConnection.makeRequest(
                     request: request,
-                    urlRequest: urlRequest
+                    urlRequest: urlRequest,
+                    urlSession: urlSession
                 )
                 
                 results.append(result)
@@ -116,7 +139,8 @@ public class DefaultNetworkConnection: NSObject, NetworkConnection {
                 dataOperationQueue.addOperation({
                     let result = DefaultNetworkConnection.makeRequest(
                         request: request,
-                        urlRequest: urlRequest
+                        urlRequest: urlRequest,
+                        urlSession: self.urlSession
                     )
                     
                     objc_sync_enter(self)
@@ -132,7 +156,7 @@ public class DefaultNetworkConnection: NSObject, NetworkConnection {
 
     // MARK: - Private methods
     
-    private static func makeRequest(request: Request, urlRequest: URLRequest) -> RequestResult {
+    private static func makeRequest(request: Request, urlRequest: URLRequest, urlSession: URLSession?) -> RequestResult {
         //source: https://forums.developer.apple.com/thread/11519
         var httpResponse: HTTPURLResponse? = nil
         var connectionError: Error? = nil
@@ -140,7 +164,7 @@ public class DefaultNetworkConnection: NSObject, NetworkConnection {
 
         sem = DispatchSemaphore(value: 0)
 
-        URLSession.shared.dataTask(with: urlRequest) { data, urlResponse, error in
+        urlSession?.dataTask(with: urlRequest) { data, urlResponse, error in
             connectionError = error
             httpResponse = urlResponse as? HTTPURLResponse
             sem.signal()

--- a/Sources/Snowplow/Network/DefaultNetworkConnection.swift
+++ b/Sources/Snowplow/Network/DefaultNetworkConnection.swift
@@ -42,7 +42,7 @@ public class DefaultNetworkConnection: NSObject, NetworkConnection {
         set(method) { _httpMethod = method; setup() }
     }
 
-    private var _emitThreadPoolSize = 15
+    private var _emitThreadPoolSize = EmitterDefaults.emitThreadPoolSize
     /// The number of threads used by the emitter.
     @objc
     public var emitThreadPoolSize: Int {
@@ -57,11 +57,11 @@ public class DefaultNetworkConnection: NSObject, NetworkConnection {
     
     /// Maximum event size for a GET request.
     @objc
-    public var byteLimitGet: Int = 40000
+    public var byteLimitGet: Int = EmitterDefaults.byteLimitGet
     
     /// Maximum event size for a POST request.
     @objc
-    public var byteLimitPost = 40000
+    public var byteLimitPost = EmitterDefaults.byteLimitPost
     
     private var _customPostPath: String?
     /// A custom path that is used on the endpoint to send requests.
@@ -78,9 +78,9 @@ public class DefaultNetworkConnection: NSObject, NetworkConnection {
     @objc
     public var serverAnonymisation = false
     private var dataOperationQueue = OperationQueue()
+    
     /// Custom timeout for the requests
-    @objc
-    public var timeout: TimeInterval
+    private var timeout: TimeInterval
     
     private var protocolClasses: [AnyClass]?
     private var _urlSession: URLSession?
@@ -102,7 +102,7 @@ public class DefaultNetworkConnection: NSObject, NetworkConnection {
                 httpMethod: HttpMethodOptions = EmitterDefaults.httpMethod,
                 protocol: ProtocolOptions = EmitterDefaults.httpProtocol,
                 customPostPath: String? = nil,
-                timeout: TimeInterval = 60,
+                timeout: TimeInterval = EmitterDefaults.emitTimeout,
                 protocolClasses: [AnyClass]? = nil) {
         self._urlString = urlString
         self.timeout = timeout

--- a/Sources/Snowplow/Network/DefaultNetworkConnection.swift
+++ b/Sources/Snowplow/Network/DefaultNetworkConnection.swift
@@ -80,7 +80,7 @@ public class DefaultNetworkConnection: NSObject, NetworkConnection {
     private var dataOperationQueue = OperationQueue()
     
     /// Custom timeout for the requests
-    private var timeout: TimeInterval
+    private let timeout: TimeInterval
     
     private var protocolClasses: [AnyClass]?
     private var _urlSession: URLSession?

--- a/Tests/TestNetworkConnection.swift
+++ b/Tests/TestNetworkConnection.swift
@@ -28,7 +28,7 @@ class TestNetworkConnection: XCTestCase {
         let endpoint = "https://\(TEST_URL_ENDPOINT)/i"
         Mock(url: URL(string: endpoint)!, ignoreQuery: true, dataType: .json, statusCode: 200, data: [.get: Data()]).register()
         
-        let connection = DefaultNetworkConnection(urlString: TEST_URL_ENDPOINT, httpMethod: .get)
+        let connection = DefaultNetworkConnection(urlString: TEST_URL_ENDPOINT, httpMethod: .get, protocolClasses: [MockingURLProtocol.self])
 
         let payload = Payload()
         payload.addValueToPayload("value", forKey: "key")
@@ -45,7 +45,7 @@ class TestNetworkConnection: XCTestCase {
         let endpoint = "https://\(TEST_URL_ENDPOINT)/i"
         Mock(url: URL(string: endpoint)!, ignoreQuery: true, dataType: .json, statusCode: 404, data: [.get: Data()]).register()
 
-        let connection = DefaultNetworkConnection(urlString: TEST_URL_ENDPOINT, httpMethod: .get)
+        let connection = DefaultNetworkConnection(urlString: TEST_URL_ENDPOINT, httpMethod: .get, protocolClasses: [MockingURLProtocol.self])
         
         let payload = Payload()
         payload.addValueToPayload("value", forKey: "key")
@@ -62,7 +62,7 @@ class TestNetworkConnection: XCTestCase {
         let endpoint = "https://\(TEST_URL_ENDPOINT)/com.snowplowanalytics.snowplow/tp2"
         Mock(url: URL(string: endpoint)!, ignoreQuery: true, dataType: .json, statusCode: 200, data: [.post: Data()]).register()
 
-        let connection = DefaultNetworkConnection(urlString: TEST_URL_ENDPOINT, httpMethod: .post)
+        let connection = DefaultNetworkConnection(urlString: TEST_URL_ENDPOINT, httpMethod: .post, protocolClasses: [MockingURLProtocol.self])
         
         let payload = Payload()
         payload.addValueToPayload("value", forKey: "key")
@@ -79,7 +79,7 @@ class TestNetworkConnection: XCTestCase {
         let endpoint = "https://\(TEST_URL_ENDPOINT)/com.snowplowanalytics.snowplow/tp2"
         Mock(url: URL(string: endpoint)!, ignoreQuery: true, dataType: .json, statusCode: 404, data: [.post: Data()]).register()
 
-        let connection = DefaultNetworkConnection(urlString: TEST_URL_ENDPOINT, httpMethod: .post)
+        let connection = DefaultNetworkConnection(urlString: TEST_URL_ENDPOINT, httpMethod: .post, protocolClasses:  [MockingURLProtocol.self])
 
         let payload = Payload()
         payload.addValueToPayload("value", forKey: "key")
@@ -124,7 +124,7 @@ class TestNetworkConnection: XCTestCase {
         }
         mock.register()
         
-        let connection = DefaultNetworkConnection(urlString: TEST_URL_ENDPOINT, httpMethod: .post)
+        let connection = DefaultNetworkConnection(urlString: TEST_URL_ENDPOINT, httpMethod: .post, protocolClasses: [MockingURLProtocol.self])
         connection.serverAnonymisation = false
 
         let payload = Payload()
@@ -149,7 +149,7 @@ class TestNetworkConnection: XCTestCase {
         }
         mock.register()
         
-        let connection = DefaultNetworkConnection(urlString: TEST_URL_ENDPOINT, httpMethod: .post)
+        let connection = DefaultNetworkConnection(urlString: TEST_URL_ENDPOINT, httpMethod: .post, protocolClasses: [MockingURLProtocol.self])
         connection.serverAnonymisation = true
 
         let payload = Payload()
@@ -174,7 +174,7 @@ class TestNetworkConnection: XCTestCase {
         }
         mock.register()
         
-        let connection = DefaultNetworkConnection(urlString: TEST_URL_ENDPOINT, httpMethod: .get)
+        let connection = DefaultNetworkConnection(urlString: TEST_URL_ENDPOINT, httpMethod: .get, protocolClasses: [MockingURLProtocol.self])
         connection.serverAnonymisation = true
 
         let payload = Payload()


### PR DESCRIPTION
Issue #836 

This PR builds on top of PR #837 to add timeout to `DefaultNetworkConnection` while considering the open comments.

Additionally, this PR adds the `timeout` configuration to the `NetworkConfiguration` similar as it is on our Android tracker. It also sets the default timeout to 30 seconds to match the Android tracker setting.