### PR TITLE
Enable lifecycle autotracking by default (close #852)

### DIFF
--- a/Sources/Core/Tracker/TrackerDefaults.swift
+++ b/Sources/Core/Tracker/TrackerDefaults.swift
@@ -24,7 +24,7 @@ class TrackerDefaults {
     private(set) static var screenContext = true
     private(set) static var applicationContext = true
     private(set) static var autotrackScreenViews = true
-    private(set) static var lifecycleEvents = false
+    private(set) static var lifecycleEvents = true
     private(set) static var exceptionEvents = true
     private(set) static var installEvent = true
     private(set) static var trackerDiagnostic = false

--- a/Sources/Snowplow/Configurations/TrackerConfiguration.swift
+++ b/Sources/Snowplow/Configurations/TrackerConfiguration.swift
@@ -57,6 +57,7 @@ public protocol TrackerConfigurationProtocol: AnyObject {
     @objc
     var screenEngagementAutotracking: Bool { get set }
     /// Whether to enable automatic tracking of background and foreground transitions.
+    /// Enabled by default.
     @objc
     var lifecycleAutotracking: Bool { get set }
     /// Whether to enable automatic tracking of install event.
@@ -207,6 +208,7 @@ public class TrackerConfiguration: SerializableConfiguration, TrackerConfigurati
     
     private var _lifecycleAutotracking: Bool?
     /// Whether to enable automatic tracking of background and foreground transitions.
+    /// Enabled by default.
     @objc
     public var lifecycleAutotracking: Bool {
         get { return _lifecycleAutotracking ?? sourceConfig?.lifecycleAutotracking ?? TrackerDefaults.lifecycleEvents }
@@ -479,6 +481,7 @@ public class TrackerConfiguration: SerializableConfiguration, TrackerConfigurati
     }
     
     /// Whether to enable automatic tracking of background and foreground transitions.
+    /// Enabled by default.
     @objc
     public func lifecycleAutotracking(_ lifecycleAutotracking: Bool) -> Self {
         self.lifecycleAutotracking = lifecycleAutotracking


### PR DESCRIPTION
Issue #852

Up to the v5 version of the tracker, lifecycle autotracking is not enabled by default. However, lifecycle events are crucial to understand the usage of the app and user engagement. It is not possible to calculate screen time without knowing whether the app is in foreground or background.

As we are introducing screen engagement tracking in the v6 version which will be enabled by default, we should also enable lifecycle tracking by default.