### PR TITLE
Set the platform event property to tv on tvOS and mobile on watchOS

### DIFF
--- a/Sources/Core/Utils/Utilities.swift
+++ b/Sources/Core/Utils/Utilities.swift
@@ -36,11 +36,13 @@ class Utilities {
     /// Returns the platform type of the device..
     /// - Returns: A string of the platform type.
     class var platform: DevicePlatform {
-        #if os(iOS) || os(visionOS)
+        #if os(iOS) || os(visionOS) || os(watchOS)
         return .mobile
 // TODO: use the headset platform by default in visionOS once Enrich 4 is commonly used
 //        #elseif os(visionOS)
 //        return .headset
+        #elseif os(tvOS)
+        return .connectedTV
         #else
         return .desktop
         #endif

--- a/Tests/TestUtils.swift
+++ b/Tests/TestUtils.swift
@@ -34,8 +34,10 @@ class TestUtils: XCTestCase {
     }
     
     func testGetPlatform() {
-#if os(iOS) || os(visionOS)
+#if os(iOS) || os(visionOS) || os(watchOS)
         XCTAssertEqual(Utilities.platform, .mobile)
+#elseif os(tvOS)
+        XCTAssertEqual(Utilities.platform, .connectedTV)
 #else
         XCTAssertEqual(Utilities.platform, .desktop)
 #endif


### PR DESCRIPTION
Previously, the `desktop` platform was used for watchOS and tvOS.

This PR changes the platform to `tv` on tvOS and `mob` on watchOS (don't have a wearable platform yet).