### PR TITLE
Remove deprecated name property in SPM package file for the Mocker dependency on Swift 5.9

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -18,7 +18,7 @@ let package = Package(
             targets: ["SnowplowTracker"]),
     ],
     dependencies: [
-        .package(name: "Mocker", url: "https://github.com/WeTransfer/Mocker.git", from: "2.5.4"),
+        .package(url: "https://github.com/WeTransfer/Mocker.git", from: "2.5.4"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Remove warning when building project with swift 5.9