### PR TITLE
Support supplying `protocolClasses` to `NetworkConfiguration`

### DIFF
--- a/Sources/Core/Emitter/Emitter.swift
+++ b/Sources/Core/Emitter/Emitter.swift
@@ -214,6 +214,7 @@ class Emitter: EmitterEventProcessing {
          serverAnonymisation: Bool? = nil,
          eventStore: EventStore? = nil,
          timeout: TimeInterval = EmitterDefaults.emitTimeout,
+         protocolClasses: [AnyClass]? = nil,
          builder: ((Emitter) -> (Void))? = nil) {
         self.namespace = namespace
         self.eventStore = eventStore ?? Emitter.defaultEventStore(namespace: namespace)
@@ -222,7 +223,8 @@ class Emitter: EmitterEventProcessing {
             urlString: urlEndpoint,
             httpMethod: method ?? EmitterDefaults.httpMethod,
             customPostPath: customPostPath,
-            timeout: timeout
+            timeout: timeout,
+            protocolClasses: protocolClasses
         )
         defaultNetworkConnection.requestHeaders = requestHeaders
         defaultNetworkConnection.serverAnonymisation = serverAnonymisation ?? EmitterDefaults.serverAnonymisation

--- a/Sources/Core/Tracker/ServiceProvider.swift
+++ b/Sources/Core/Tracker/ServiceProvider.swift
@@ -265,6 +265,7 @@ class ServiceProvider: NSObject, ServiceProviderProtocol {
                 serverAnonymisation: self.emitterConfiguration.serverAnonymisation,
                 eventStore: self.emitterConfiguration.eventStore,
                 timeout: self.networkConfiguration.timeout,
+                protocolClasses: self.networkConfiguration.protocolClasses,
                 builder: builder
             )
         }

--- a/Sources/Snowplow/Configurations/NetworkConfiguration.swift
+++ b/Sources/Snowplow/Configurations/NetworkConfiguration.swift
@@ -40,6 +40,15 @@ public class NetworkConfiguration: SerializableConfiguration, ConfigurationProto
         set { _protocol = newValue }
     }
     
+    
+    private var _protocolClasses: [AnyClass]?
+    /// Array of `NSURLProtocol` in order to supply to `DefaultNetworkConnection`.
+    @objc
+    private(set) public var protocolClasses: [AnyClass]? {
+        get { return _protocolClasses }
+        set { _protocolClasses = newValue }
+    }
+
     private var _networkConnection: NetworkConnection?
     /// See `NetworkConfiguration(NetworkConnection)`
     @objc

--- a/Sources/Snowplow/Configurations/NetworkConfiguration.swift
+++ b/Sources/Snowplow/Configurations/NetworkConfiguration.swift
@@ -155,6 +155,13 @@ public class NetworkConfiguration: SerializableConfiguration, ConfigurationProto
         self.timeout = timeout
         return self
     }
+    
+    /// Array of `NSURLProtocol` in order to supply to `DefaultNetworkConnection`.
+    @objc
+    public func protocolClasses(_ protocolClasses: [AnyClass]?) -> Self {
+        self.protocolClasses = protocolClasses
+        return self
+    }
 
     // MARK: - NSCopying
 

--- a/Tests/Configurations/TestConfigurationBuilder.swift
+++ b/Tests/Configurations/TestConfigurationBuilder.swift
@@ -30,7 +30,10 @@ class TestConfigurationBuilder: XCTestCase {
             
             EmitterConfiguration()
                 .threadPoolSize(33)
-            
+
+            NetworkConfiguration(endpoint: "https://snowplow.io", method: .post)
+                .protocolClasses([])
+
             if let pluginName = pluginName {
                 PluginConfiguration(identifier: pluginName)
                     .afterTrack { event in }


### PR DESCRIPTION
We wish to use Mocking libraries such as [OHHTTPStubs](https://github.com/AliSoftware/OHHTTPStubs) or [Mocker](https://github.com/WeTransfer/Mocker) to build automated end 2 end testing solution in order to validate our Snowplow events are emitting.

Currently `DefaultNetworkConnection` provides an empty an array of `protocolClasses` to the `URLSessionConfiguration`
This overrides the swizzling performed by [HTTPStubs.m](https://github.com/AliSoftware/OHHTTPStubs/blob/master/Sources/OHHTTPStubs/HTTPStubs.m#L196)

By adding `protocolClasses` property to `NetworkConfiguration` we enable supplying the network connection with custom protocols and prevent overriding swizzled properties during testing.

We can supply protocol classes such as:

```swift
Snowplow.createTracker() {
    NetworkConfiguration()
        .protocolClasses([CustomURLProtocol.self])
```