### PR TITLE
Do not swizzle views if screen view autotracking is disabled (close #889)

### DIFF
--- a/Sources/Core/Tracker/Tracker.swift
+++ b/Sources/Core/Tracker/Tracker.swift
@@ -171,7 +171,17 @@ class Tracker: NSObject {
     
     var applicationContext = TrackerDefaults.applicationContext
     
-    var autotrackScreenViews = TrackerDefaults.autotrackScreenViews
+    private var _autotrackScreenViews = TrackerDefaults.autotrackScreenViews
+    var autotrackScreenViews: Bool {
+        get { return _autotrackScreenViews }
+        set {
+            _autotrackScreenViews = newValue
+            if builderFinished && _autotrackScreenViews {
+                UIKitScreenViewTracking.setup()
+            }
+        }
+    }
+    
     
     private var _foregroundTimeout = TrackerDefaults.foregroundTimeout
     var foregroundTimeout: Int {
@@ -292,7 +302,9 @@ class Tracker: NSObject {
                 tracker: self)
         }
 
-        UIKitScreenViewTracking.setup()
+        if autotrackScreenViews {
+            UIKitScreenViewTracking.setup()
+        }
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(receiveScreenViewNotification(_:)),


### PR DESCRIPTION
Issue #889 

Conditionally performs UIKit swizzling in order to set up screen view autotracking.

Previously swizzling was done even if autotracking was disabled, this was not necessary and could cause problems in some apps.

This is PR adds a condition to not perform swizzling if autotracking is disabled.