### PR TITLE
Add the PrivacyInfo to the CocoaPods podspec (close #888)

### DIFF
--- a/SnowplowTracker.podspec
+++ b/SnowplowTracker.podspec
@@ -31,4 +31,5 @@ Pod::Spec.new do |s|
     end
   
     s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
+    s.resource_bundles = {'SnowplowTracker_Privacy' => ['PrivacyInfo.xcprivacy']}
   end


### PR DESCRIPTION
Issue #888 


The privacy info file was previously not exposed from the package when used through CocoaPods. This PR adds it to the resources for CocoaPods so that it is included.