### PR TITLE
Release/6.0.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Version 6.0.3 (2024-05-13)
+--------------------------
+Add the PrivacyInfo to the CocoaPods podspec (#888)
+Do not swizzle views if screen view autotracking is disabled (#889)
+
 Version 6.0.2 (2024-04-02)
 --------------------------
 Fix non-published constructor for MediaPlaybackRateChangeEvent (#884)

--- a/SnowplowTracker.podspec
+++ b/SnowplowTracker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "SnowplowTracker"
-    s.version          = "6.0.2"
+    s.version          = "6.0.3"
     s.summary          = "Snowplow event tracker for iOS, macOS, tvOS, watchOS for apps and games."
     s.description      = <<-DESC
     Snowplow is a mobile and event analytics platform with a difference: rather than tell our users how they should analyze their data, we deliver their event-level data in their own data warehouse, on their own Amazon Redshift or Postgres database, so they can analyze it any way they choose. Snowplow mobile is used by data-savvy games companies and app developers to better understand their users and how they engage with their games and applications. Snowplow is open source using the business-friendly Apache License, Version 2.0 and scales horizontally to many billions of events.

--- a/SnowplowTracker.podspec
+++ b/SnowplowTracker.podspec
@@ -31,4 +31,5 @@ Pod::Spec.new do |s|
     end
   
     s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
+    s.resource_bundles = {'SnowplowTracker_Privacy' => ['PrivacyInfo.xcprivacy']}
   end

--- a/Sources/Core/Tracker/Tracker.swift
+++ b/Sources/Core/Tracker/Tracker.swift
@@ -171,7 +171,17 @@ class Tracker: NSObject {
     
     var applicationContext = TrackerDefaults.applicationContext
     
-    var autotrackScreenViews = TrackerDefaults.autotrackScreenViews
+    private var _autotrackScreenViews = TrackerDefaults.autotrackScreenViews
+    var autotrackScreenViews: Bool {
+        get { return _autotrackScreenViews }
+        set {
+            _autotrackScreenViews = newValue
+            if builderFinished && _autotrackScreenViews {
+                UIKitScreenViewTracking.setup()
+            }
+        }
+    }
+    
     
     private var _foregroundTimeout = TrackerDefaults.foregroundTimeout
     var foregroundTimeout: Int {
@@ -292,7 +302,9 @@ class Tracker: NSObject {
                 tracker: self)
         }
 
-        UIKitScreenViewTracking.setup()
+        if autotrackScreenViews {
+            UIKitScreenViewTracking.setup()
+        }
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(receiveScreenViewNotification(_:)),

--- a/Sources/Core/TrackerConstants.swift
+++ b/Sources/Core/TrackerConstants.swift
@@ -14,7 +14,7 @@
 import Foundation
 
 // --- Version
-let kSPRawVersion = "6.0.2"
+let kSPRawVersion = "6.0.3"
 #if os(iOS)
 let kSPVersion = "ios-\(kSPRawVersion)"
 #elseif os(tvOS)


### PR DESCRIPTION
This release disables UIKit view swizzling in case automatic screen view tracking is disabled. It also adds the PrivacyInfo manifest to Cocoapods.

**Bug fixes**
* Add the PrivacyInfo to the CocoaPods podspec (#888)
* Do not swizzle views if screen view autotracking is disabled (#889)