### PR TITLE
Make CrossDeviceParameterConfiguration init public

### DIFF
--- a/Sources/Snowplow/Tracker/CrossDeviceParameterConfiguration.swift
+++ b/Sources/Snowplow/Tracker/CrossDeviceParameterConfiguration.swift
@@ -26,7 +26,7 @@ import Foundation
     /// Optional identifier/information for cross-navigation
     @objc var reason: String?
     
-    @objc init(
+    @objc public init(
         sessionId: Bool = true,
         subjectUserId: Bool = false,
         sourceId: Bool = true,


### PR DESCRIPTION
When trying to decorate a link with extended parameters, this error presents itself: `'CrossDeviceParameterConfiguration' initializer is inaccessible due to 'internal' protection level`.

```swift
tracker.decorateLink(
            URL(string: "https://test.com/")!,
            extendedParameters: CrossDeviceParameterConfiguration(
                sessionId: true,
                subjectUserId: true,
                sourceId: true,
                sourcePlatform: true,
                reason: "this is a reason"
            )
)
```

From [the examples](https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/mobile-trackers/tracking-events/session-tracking/#decorating-outgoing-links-using-cross-navigation-tracking), it looks like the initializer is meant to be public.

This PR simply adds `public` to the `init` method of the `CrossDeviceParameterConfiguration` class.