### PR TITLE
Add warning for the serialization of data in self-describing event and entity

### DIFF
--- a/Sources/Snowplow/Events/SelfDescribing.swift
+++ b/Sources/Snowplow/Events/SelfDescribing.swift
@@ -21,6 +21,12 @@ public class SelfDescribing: SelfDescribingAbstract {
         self.init(schema: eventData.schema, payload: eventData.data)
     }
 
+    /// Creates a self-describing event using data represented as an Encodable struct.
+    /// NOTE: The data should be serializable to JSON using the JSONSerialization class in Foundation. An exception will be thrown if the data is not serializable. To make sure your data is serializable, you can use the `JSONSerialization.isValidJSONObject` function.
+    /// - Parameters:
+    ///   - schema: A valid schema URI.
+    ///   - payload: Payload for the event.
+    /// - Returns: A SelfDescribing event.
     @objc
     public init(schema: String, payload: [String : Any]) {
         self._schema = schema
@@ -28,6 +34,7 @@ public class SelfDescribing: SelfDescribingAbstract {
     }
     
     /// Creates a self-describing event using data represented as an Encodable struct.
+    /// NOTE: The data should be serializable to JSON using the JSONSerialization class in Foundation. An exception will be thrown if the data is not serializable. To make sure your data is serializable, you can use the `JSONSerialization.isValidJSONObject` function.
     /// - Parameters:
     ///   - schema: A valid schema URI.
     ///   - data: Data represented using an Encodable struct.

--- a/Sources/Snowplow/Payload/SelfDescribingJson.swift
+++ b/Sources/Snowplow/Payload/SelfDescribingJson.swift
@@ -42,6 +42,7 @@ public class SelfDescribingJson: NSObject {
     }
 
     /// Initializes a newly allocated SPSelfDescribingJson.
+    /// NOTE: The data should be serializable to JSON using the JSONSerialization class in Foundation. An exception will be thrown if the data is not serializable. To make sure your data is serializable, you can use the `JSONSerialization.isValidJSONObject` function.
     /// - Parameters:
     ///   - schema: A valid schema string.
     ///   - data: Data to set for data field of the self-describing JSON, should be an NSDictionary.
@@ -54,6 +55,7 @@ public class SelfDescribingJson: NSObject {
     }
 
     /// Initializes a newly allocated SPSelfDescribingJson.
+    /// NOTE: The data should be serializable to JSON using the JSONSerialization class in Foundation. An exception will be thrown if the data is not serializable. To make sure your data is serializable, you can use the `JSONSerialization.isValidJSONObject` function.
     /// - Parameters:
     ///   - schema: A valid schema string.
     ///   - data: Dictionary to set for data field of the self-describing JSON.
@@ -64,6 +66,7 @@ public class SelfDescribingJson: NSObject {
     }
 
     /// Initializes a newly allocated SPSelfDescribingJson.
+    /// NOTE: The payload should be serializable to JSON using the JSONSerialization class in Foundation. An exception will be thrown if the data is not serializable. To make sure your data is serializable, you can use the `JSONSerialization.isValidJSONObject` function.
     /// - Parameters:
     ///   - schema: A valid schema string.
     ///   - data: Payload to set for data field of the self-describing JSON.
@@ -74,6 +77,7 @@ public class SelfDescribingJson: NSObject {
     }
 
     /// Initializes a newly allocated SPSelfDescribingJson.
+    /// NOTE: The data should be serializable to JSON using the JSONSerialization class in Foundation. An exception will be thrown if the data is not serializable. To make sure your data is serializable, you can use the `JSONSerialization.isValidJSONObject` function.
     /// - Parameters:
     ///   - schema: A valid schema URI.
     ///   - data: Self-describing JSON to set for data field of the self-describing JSON.
@@ -104,6 +108,7 @@ public class SelfDescribingJson: NSObject {
     }
 
     /// Sets the data field of the self-describing JSON.
+    /// NOTE: The data should be serializable to JSON using the JSONSerialization class in Foundation. An exception will be thrown if the data is not serializable. To make sure your data is serializable, you can use the `JSONSerialization.isValidJSONObject` function.
     /// - Parameter data: A self-describing JSON to be nested into the data.
     @objc
     public func setData(withSelfDescribingJson data: SelfDescribingJson) {


### PR DESCRIPTION
This PR adds a warning to `SelfDescribingJSON` and `SelfDescribing` classes to warn that the data needs to be serializable to JSON, otherwise an error will be thrown.