### PR TITLE
Release/6.0.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Lint Podspec
         run: pod lib lint --platforms=${{ matrix.platform }}
 
@@ -56,12 +56,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # -- Micro --
       - name: Cache Micro
         id: cache-micro
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: micro.jar
           key: ${{ runner.os }}-micro
@@ -130,7 +130,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -167,7 +167,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -204,7 +204,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -250,7 +250,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Version 6.0.5 (2024-07-03)
+--------------------------
+Stop sending if events fail to be removed from the event store
+Add warning for the serialization of data in self-describing event and entity (#898)
+
 Version 6.0.4 (2024-06-12)
 --------------------------
 Fix CrossDeviceParameterConfiguration constructor to be public (#894) thanks to @thomas-brx

--- a/SnowplowTracker.podspec
+++ b/SnowplowTracker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "SnowplowTracker"
-    s.version          = "6.0.4"
+    s.version          = "6.0.5"
     s.summary          = "Snowplow event tracker for iOS, macOS, tvOS, watchOS for apps and games."
     s.description      = <<-DESC
     Snowplow is a mobile and event analytics platform with a difference: rather than tell our users how they should analyze their data, we deliver their event-level data in their own data warehouse, on their own Amazon Redshift or Postgres database, so they can analyze it any way they choose. Snowplow mobile is used by data-savvy games companies and app developers to better understand their users and how they engage with their games and applications. Snowplow is open source using the business-friendly Apache License, Version 2.0 and scales horizontally to many billions of events.

--- a/Sources/Core/Emitter/Emitter.swift
+++ b/Sources/Core/Emitter/Emitter.swift
@@ -350,7 +350,7 @@ class Emitter: EmitterEventProcessing {
             }
             let allFailureCount = failedWillRetryCount + failedWontRetryCount
             
-            _ = self.eventStore.removeEvents(withIds: removableEvents)
+            let eventsRemoved = removableEvents.isEmpty ? true : self.eventStore.removeEvents(withIds: removableEvents)
             
             logDebug(message: String(format: "Success Count: %d", successCount))
             logDebug(message: String(format: "Failure Count: %d", allFailureCount))
@@ -365,6 +365,10 @@ class Emitter: EmitterEventProcessing {
             
             if failedWillRetryCount > 0 && successCount == 0 {
                 logDebug(message: "Ending emitter run as all requests failed.")
+                
+                self.scheduleStopSending()
+            } else if !eventsRemoved {
+                logDebug(message: "Ending emitter run as failed to remove events from event store.")
                 
                 self.scheduleStopSending()
             } else {

--- a/Sources/Core/TrackerConstants.swift
+++ b/Sources/Core/TrackerConstants.swift
@@ -14,7 +14,7 @@
 import Foundation
 
 // --- Version
-let kSPRawVersion = "6.0.4"
+let kSPRawVersion = "6.0.5"
 #if os(iOS)
 let kSPVersion = "ios-\(kSPRawVersion)"
 #elseif os(tvOS)

--- a/Sources/Snowplow/Events/SelfDescribing.swift
+++ b/Sources/Snowplow/Events/SelfDescribing.swift
@@ -21,6 +21,12 @@ public class SelfDescribing: SelfDescribingAbstract {
         self.init(schema: eventData.schema, payload: eventData.data)
     }
 
+    /// Creates a self-describing event using data represented as an Encodable struct.
+    /// NOTE: The data should be serializable to JSON using the JSONSerialization class in Foundation. An exception will be thrown if the data is not serializable. To make sure your data is serializable, you can use the `JSONSerialization.isValidJSONObject` function.
+    /// - Parameters:
+    ///   - schema: A valid schema URI.
+    ///   - payload: Payload for the event.
+    /// - Returns: A SelfDescribing event.
     @objc
     public init(schema: String, payload: [String : Any]) {
         self._schema = schema
@@ -28,6 +34,7 @@ public class SelfDescribing: SelfDescribingAbstract {
     }
     
     /// Creates a self-describing event using data represented as an Encodable struct.
+    /// NOTE: The data should be serializable to JSON using the JSONSerialization class in Foundation. An exception will be thrown if the data is not serializable. To make sure your data is serializable, you can use the `JSONSerialization.isValidJSONObject` function.
     /// - Parameters:
     ///   - schema: A valid schema URI.
     ///   - data: Data represented using an Encodable struct.

--- a/Sources/Snowplow/Payload/SelfDescribingJson.swift
+++ b/Sources/Snowplow/Payload/SelfDescribingJson.swift
@@ -42,6 +42,7 @@ public class SelfDescribingJson: NSObject {
     }
 
     /// Initializes a newly allocated SPSelfDescribingJson.
+    /// NOTE: The data should be serializable to JSON using the JSONSerialization class in Foundation. An exception will be thrown if the data is not serializable. To make sure your data is serializable, you can use the `JSONSerialization.isValidJSONObject` function.
     /// - Parameters:
     ///   - schema: A valid schema string.
     ///   - data: Data to set for data field of the self-describing JSON, should be an NSDictionary.
@@ -54,6 +55,7 @@ public class SelfDescribingJson: NSObject {
     }
 
     /// Initializes a newly allocated SPSelfDescribingJson.
+    /// NOTE: The data should be serializable to JSON using the JSONSerialization class in Foundation. An exception will be thrown if the data is not serializable. To make sure your data is serializable, you can use the `JSONSerialization.isValidJSONObject` function.
     /// - Parameters:
     ///   - schema: A valid schema string.
     ///   - data: Dictionary to set for data field of the self-describing JSON.
@@ -64,6 +66,7 @@ public class SelfDescribingJson: NSObject {
     }
 
     /// Initializes a newly allocated SPSelfDescribingJson.
+    /// NOTE: The payload should be serializable to JSON using the JSONSerialization class in Foundation. An exception will be thrown if the data is not serializable. To make sure your data is serializable, you can use the `JSONSerialization.isValidJSONObject` function.
     /// - Parameters:
     ///   - schema: A valid schema string.
     ///   - data: Payload to set for data field of the self-describing JSON.
@@ -74,6 +77,7 @@ public class SelfDescribingJson: NSObject {
     }
 
     /// Initializes a newly allocated SPSelfDescribingJson.
+    /// NOTE: The data should be serializable to JSON using the JSONSerialization class in Foundation. An exception will be thrown if the data is not serializable. To make sure your data is serializable, you can use the `JSONSerialization.isValidJSONObject` function.
     /// - Parameters:
     ///   - schema: A valid schema URI.
     ///   - data: Self-describing JSON to set for data field of the self-describing JSON.
@@ -104,6 +108,7 @@ public class SelfDescribingJson: NSObject {
     }
 
     /// Sets the data field of the self-describing JSON.
+    /// NOTE: The data should be serializable to JSON using the JSONSerialization class in Foundation. An exception will be thrown if the data is not serializable. To make sure your data is serializable, you can use the `JSONSerialization.isValidJSONObject` function.
     /// - Parameter data: A self-describing JSON to be nested into the data.
     @objc
     public func setData(withSelfDescribingJson data: SelfDescribingJson) {

--- a/Tests/Utils/MockEventStore.swift
+++ b/Tests/Utils/MockEventStore.swift
@@ -18,6 +18,7 @@ class MockEventStore: NSObject, EventStore {
     
     var db: [Int64 : Payload] = [:]
     var lastInsertedRow = 0
+    var failToRemoveEvents = false
 
     override init() {
         super.init()
@@ -32,22 +33,34 @@ class MockEventStore: NSObject, EventStore {
     }
 
     func removeEvent(withId storeId: Int64) -> Bool {
-        logVerbose(message: "Remove \(storeId)")
-        return db.removeValue(forKey: storeId) != nil
+        if failToRemoveEvents {
+            return false
+        } else {
+            logVerbose(message: "Remove \(storeId)")
+            return db.removeValue(forKey: storeId) != nil
+        }
     }
 
     func removeEvents(withIds storeIds: [Int64]) -> Bool {
-        let result = true
-        for storeId in storeIds {
-            db.removeValue(forKey: storeId)
+        if failToRemoveEvents {
+            return false
+        } else {
+            let result = true
+            for storeId in storeIds {
+                db.removeValue(forKey: storeId)
+            }
+            return result
         }
-        return result
     }
 
     func removeAllEvents() -> Bool {
-        db.removeAll()
-        lastInsertedRow = -1
-        return true
+        if failToRemoveEvents {
+            return false
+        } else {
+            db.removeAll()
+            lastInsertedRow = -1
+            return true
+        }
     }
 
     func count() -> UInt {


### PR DESCRIPTION
This patch release makes the emitter pause for 5 seconds in case events fail to be removed from the event store. This aims to reduce the number of duplicates caused in case of issues with removing events from the SQLite event store.

It also adds a warning to the API docs that the self-describing event and entity data may needs to be serializable to JSON.

**Bug fixes**
* Stop sending if events fail to be removed from the event store
* Add warning for the serialization of data in self-describing event and entity (#898)
