### PR TITLE
Release/6.0.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 6.0.6 (2024-07-10)
+--------------------------
+Fix remote configuration attempting to serialize a logger class after new configuration is fetched (#900)
+
 Version 6.0.5 (2024-07-03)
 --------------------------
 Stop sending if events fail to be removed from the event store

--- a/SnowplowTracker.podspec
+++ b/SnowplowTracker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "SnowplowTracker"
-    s.version          = "6.0.5"
+    s.version          = "6.0.6"
     s.summary          = "Snowplow event tracker for iOS, macOS, tvOS, watchOS for apps and games."
     s.description      = <<-DESC
     Snowplow is a mobile and event analytics platform with a difference: rather than tell our users how they should analyze their data, we deliver their event-level data in their own data warehouse, on their own Amazon Redshift or Postgres database, so they can analyze it any way they choose. Snowplow mobile is used by data-savvy games companies and app developers to better understand their users and how they engage with their games and applications. Snowplow is open source using the business-friendly Apache License, Version 2.0 and scales horizontally to many billions of events.

--- a/Sources/Core/TrackerConstants.swift
+++ b/Sources/Core/TrackerConstants.swift
@@ -14,7 +14,7 @@
 import Foundation
 
 // --- Version
-let kSPRawVersion = "6.0.5"
+let kSPRawVersion = "6.0.6"
 #if os(iOS)
 let kSPVersion = "ios-\(kSPRawVersion)"
 #elseif os(tvOS)

--- a/Sources/Snowplow/Configurations/TrackerConfiguration.swift
+++ b/Sources/Snowplow/Configurations/TrackerConfiguration.swift
@@ -588,7 +588,6 @@ public class TrackerConfiguration: SerializableConfiguration, TrackerConfigurati
         coder.encode(devicePlatform.rawValue, forKey: "devicePlatform")
         coder.encode(base64Encoding, forKey: "base64Encoding")
         coder.encode(logLevel.rawValue, forKey: "logLevel")
-        coder.encode(loggerDelegate, forKey: "loggerDelegate")
         coder.encode(sessionContext, forKey: "sessionContext")
         coder.encode(applicationContext, forKey: "applicationContext")
         coder.encode(platformContext, forKey: "platformContext")
@@ -617,9 +616,6 @@ public class TrackerConfiguration: SerializableConfiguration, TrackerConfigurati
         base64Encoding = coder.decodeBool(forKey: "base64Encoding")
         if let logLevel = LogLevel(rawValue: coder.decodeInteger(forKey: "logLevel")) {
             self.logLevel = logLevel
-        }
-        if let loggerDelegate = coder.decodeObject(forKey: "loggerDelegate") as? LoggerDelegate {
-            self.loggerDelegate = loggerDelegate
         }
         sessionContext = coder.decodeBool(forKey: "sessionContext")
         applicationContext = coder.decodeBool(forKey: "applicationContext")


### PR DESCRIPTION
This PR fixes a bug in remote configuration that resulted in a crash in case the tracker configuration had a logger class configured, which the tracker previously tried to serialize on remote config updates. The logger class is no longer serialized, but it still can persist on config updates as the new tracker configuration can fallback on the previous one for that property.

**Bug fixes**
* Fix remote configuration attempting to serialize a logger class after new configuration is fetched (#900)