### PR TITLE
Release/6.0.8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 6.0.8 (2024-08-19)
+--------------------------
+Fix media tracking calls not being dispatched on the correct queue when tracking using AVPlayer
+
 Version 6.0.7 (2024-07-16)
 --------------------------
 Fix incorrect decoding of timeout property in network configuration (#902)

--- a/Integrationtests/TestTrackEventsToMicro.swift
+++ b/Integrationtests/TestTrackEventsToMicro.swift
@@ -13,6 +13,9 @@
 
 import XCTest
 import SnowplowTracker
+#if !os(watchOS)
+import AVKit
+#endif
 
 class TestTrackEventsToMicro: XCTestCase {
     var tracker: TrackerController?
@@ -165,6 +168,16 @@ class TestTrackEventsToMicro: XCTestCase {
             }
         ], timeout: Micro.timeout)
     }
+    
+#if !os(watchOS)
+    func testMediaTrackingUsingAVPlayer() {
+        let player = AVPlayer()
+        let mediaTracking = tracker?.media.startMediaTracking(player: player, configuration: MediaTrackingConfiguration(id: "integration-test"))
+        mediaTracking?.track(MediaReadyEvent())
+        
+        wait(for: [Micro.expectCounts(good: 1)], timeout: Micro.timeout)
+    }
+#endif
     
     private func track(_ event: Event) {
         _ = tracker!.track(event)

--- a/SnowplowTracker.podspec
+++ b/SnowplowTracker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "SnowplowTracker"
-    s.version          = "6.0.7"
+    s.version          = "6.0.8"
     s.summary          = "Snowplow event tracker for iOS, macOS, tvOS, watchOS for apps and games."
     s.description      = <<-DESC
     Snowplow is a mobile and event analytics platform with a difference: rather than tell our users how they should analyze their data, we deliver their event-level data in their own data warehouse, on their own Amazon Redshift or Postgres database, so they can analyze it any way they choose. Snowplow mobile is used by data-savvy games companies and app developers to better understand their users and how they engage with their games and applications. Snowplow is open source using the business-friendly Apache License, Version 2.0 and scales horizontally to many billions of events.

--- a/Sources/Core/InternalQueue/MediaControllerIQWrapper.swift
+++ b/Sources/Core/InternalQueue/MediaControllerIQWrapper.swift
@@ -45,7 +45,9 @@ class MediaControllerIQWrapper: MediaController {
 #if !os(watchOS)
     func startMediaTracking(player: AVPlayer,
                             configuration: MediaTrackingConfiguration) -> MediaTracking {
-        return InternalQueue.sync { controller.startMediaTracking(player: player, configuration: configuration) }
+        return InternalQueue.sync {
+            MediaTrackingIQWrapper(tracking: controller.startMediaTracking(player: player, configuration: configuration))
+        }
     }
 #endif
     

--- a/Sources/Core/TrackerConstants.swift
+++ b/Sources/Core/TrackerConstants.swift
@@ -14,7 +14,7 @@
 import Foundation
 
 // --- Version
-let kSPRawVersion = "6.0.7"
+let kSPRawVersion = "6.0.8"
 #if os(iOS)
 let kSPVersion = "ios-\(kSPRawVersion)"
 #elseif os(tvOS)


### PR DESCRIPTION
This patch release fixes a bug that caused the tracking events to crash when media tracking was started using an `AVPlayer` instance.

**Bug fixes**
* Fix media tracking calls not being dispatched on the correct queue when tracking using AVPlayer