### PR TITLE
Makes SelfDescribingJson open

### DIFF
--- a/Sources/Snowplow/Payload/SelfDescribingJson.swift
+++ b/Sources/Snowplow/Payload/SelfDescribingJson.swift
@@ -18,7 +18,7 @@ import Foundation
 /// This class holds the information of a self-describing JSON.
 /// - seealso: SPPayload
 @objc(SPSelfDescribingJson)
-public class SelfDescribingJson: NSObject {
+open class SelfDescribingJson: NSObject {
     /// the schema URI for this self-describing JSON.
     @objc
     public var schema: String


### PR DESCRIPTION
This allows inheritance on the client side. This was the behaviour available with Objc version of the SDK and one I could not find any drawbacks of in the current state of the SDK. Being able to inherit allows the use of type's init while preserving `SelfDescribingJson` identity. This allow to put subclasses in place of `SelfDescribingJson` and still preserve types.

I've also checked that making `SelfDescribing` `open works just as fine, though, it does require making a few helpers types `open` as well. However, I haven't found similar applications for `SelfDescribing` as for `SelfDescribingJson` that would justify these side-effects. Hence, it's not included in this PR.

### Example
Take a look at the wrapper I've been using for LinkClick events:
```swift
final class LinkClick: SelfDescribingJson {
    init?(
        elementId: String,
        targetUrl: String,
        elementContent: String,
        elementClasses: [ElementClass] = [],
        elementTarget: String = ""
    ) {
        var data = [String: Any]()
        
        if !elementId.isEmpty {
            data["elementId"] = elementId
        }
        if !targetUrl.isEmpty {
            data["targetUrl"] = targetUrl
        } else {
            assertionFailure("targetUrl is required by the schema.")
        }
        if !elementContent.isEmpty {
            data["elementContent"] = elementContent
        }
        if !elementClasses.isEmpty {
            data["elementClasses"] = elementClasses.map(\.rawValue)
        }
        if !elementTarget.isEmpty {
            data["elementTarget"] = elementTarget
        }
        
        super.init(
            schema: "iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1",
            andData: data as NSDictionary
        )
    }
    
    enum ElementClass {
        case toggle, link, button, custom(String)
        
        var rawValue: String {
            return switch self {
            case .toggle: "toggle"
            case .link: "link"
            case .button: "button"
            case .custom(let value): value
            }
        }
    }
}
```
It provides static type safety and ease of setting necessary parameters. At the same time I'm using event assemblies like this:
```swift
struct EventName: EventAssembly {
    let payload: SelfDescribingJson?
    let contexts: [SelfDescribingJson?]
    
    public init(parameterName: String) {
        payload = JSON.LinkClick(
            ...
        )
        contexts = [
            JSON.ContextSource(
                ...
            )
        ]
    }
}
```
to separately generate payload and contexts and assemble them only later when needed.

This allows having access to individual parts of event(payload and contexts), differentiating events with dynamic type casting if needed in rare circumstances and all with an extremely lightweight syntax. 
This can be partially replicated with global/static functions, but it will be much more cumbersome and there will be no way to have different types under `SelfDescribingJson` parent.
