### PR TITLE
Handle nan values and other non-serializable data in events from the WebView tracker

### DIFF
--- a/Sources/Core/Tracker/WebViewMessageHandler.swift
+++ b/Sources/Core/Tracker/WebViewMessageHandler.swift
@@ -40,6 +40,11 @@ class WebViewMessageHandler: NSObject, WKScriptMessageHandler {
             let context = body["context"] as? [[AnyHashable : Any]] ?? []
             let trackers = body["trackers"] as? [String] ?? []
             
+            if !JSONSerialization.isValidJSONObject(event) || !JSONSerialization.isValidJSONObject(context) {
+                logError(message: "WebView: Received event payload is not serializable to JSON, skipping.")
+                return
+            }
+            
             if command == "trackSelfDescribingEvent" {
                 trackSelfDescribing(event, withContext: context, andTrackers: trackers)
             } else if command == "trackStructEvent" {

--- a/Tests/TestWebViewMessageHandler.swift
+++ b/Tests/TestWebViewMessageHandler.swift
@@ -126,5 +126,41 @@ class TestWebViewMessageHandler: XCTestCase {
         let context = payload?["co"] as? String
         XCTAssert(context?.contains("{\"a\":\"b\"}") ?? false)
     }
+    
+    func testHandlesNonJSONSerializableDataInEvent() {
+        let message = MockWKScriptMessage(
+            body: [
+                "command": "trackSelfDescribingEvent",
+                "event": [
+                    "schema": "http://schema.com",
+                    "data": [
+                        "key": Double.nan
+                    ]
+                ]
+            ])
+        webViewMessageHandler?.receivedMesssage(message) // shouldn't crash
+    }
+    
+    func testHandlesNonJSONSerializableDataInContext() {
+        let message = MockWKScriptMessage(
+            body: [
+                "command": "trackSelfDescribingEvent",
+                "event": [
+                    "schema": "http://schema.com",
+                    "data": [
+                        "key": "val"
+                    ]
+                ],
+                "context": [
+                    [
+                        "schema": "http://context-schema.com",
+                        "data": [
+                            "a": Double.nan
+                        ]
+                    ]
+                ]
+            ])
+        webViewMessageHandler?.receivedMesssage(message) // shouldn't crash
+    }
 }
 #endif


### PR DESCRIPTION
This fixes the problem when in case the WebView tracker tracked event or context data that included NaN values, the tracker and the app would crash.

In order to handle this case, this PR adds a a check for `JSONSerialization.isValidJSONObject` on both the event and context entities. In case either is not serializable, an error is logged and the event is skipped.