### PR TITLE
Release/6.1.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 6.1.0 (2025-01-16)
+--------------------------
+Add new WebView interface (#913)
+
 Version 6.0.9 (2024-11-21)
 --------------------------
 Handle nan values and other non-serializable data in events from the WebView tracker (#909)

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,16 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-docc-symbolkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-symbolkit",
-      "state" : {
-        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "revision" : "3303b164430d9a7055ba484c8ead67a52f7b74f6",
         "version" : "1.0.0"
       }
     }

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,7 +14,16 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
       }
     }

--- a/SnowplowTracker.podspec
+++ b/SnowplowTracker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "SnowplowTracker"
-    s.version          = "6.0.9"
+    s.version          = "6.1.0"
     s.summary          = "Snowplow event tracker for iOS, macOS, tvOS, watchOS for apps and games."
     s.description      = <<-DESC
     Snowplow is a mobile and event analytics platform with a difference: rather than tell our users how they should analyze their data, we deliver their event-level data in their own data warehouse, on their own Amazon Redshift or Postgres database, so they can analyze it any way they choose. Snowplow mobile is used by data-savvy games companies and app developers to better understand their users and how they engage with their games and applications. Snowplow is open source using the business-friendly Apache License, Version 2.0 and scales horizontally to many billions of events.

--- a/Sources/Core/Events/WebViewReader.swift
+++ b/Sources/Core/Events/WebViewReader.swift
@@ -1,0 +1,126 @@
+//  Copyright (c) 2013-present Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+
+import Foundation
+
+/// Allows the tracking of JavaScript events from WebViews.
+class WebViewReader: Event {
+    let selfDescribingEventData: SelfDescribingJson?
+    let eventName: String?
+    let trackerVersion: String?
+    let useragent: String?
+    let pageUrl: String?
+    let pageTitle: String?
+    let referrer: String?
+    let category: String?
+    let action: String?
+    let label: String?
+    let property: String?
+    let value: Double?
+    let pingXOffsetMin: Int?
+    let pingXOffsetMax: Int?
+    let pingYOffsetMin: Int?
+    let pingYOffsetMax: Int?
+    
+    init(
+        selfDescribingEventData: SelfDescribingJson? = nil,
+        eventName: String? = nil,
+        trackerVersion: String? = nil,
+        useragent: String? = nil,
+        pageUrl: String? = nil,
+        pageTitle: String? = nil,
+        referrer: String? = nil,
+        category: String? = nil,
+        action: String? = nil,
+        label: String? = nil,
+        property: String? = nil,
+        value: Double? = nil,
+        pingXOffsetMin: Int? = nil,
+        pingXOffsetMax: Int? = nil,
+        pingYOffsetMin: Int? = nil,
+        pingYOffsetMax: Int? = nil
+    ) {
+        self.selfDescribingEventData = selfDescribingEventData
+        self.eventName = eventName
+        self.trackerVersion = trackerVersion
+        self.useragent = useragent
+        self.pageUrl = pageUrl
+        self.pageTitle = pageTitle
+        self.referrer = referrer
+        self.category = category
+        self.action = action
+        self.label = label
+        self.property = property
+        self.value = value
+        self.pingXOffsetMin = pingXOffsetMin
+        self.pingXOffsetMax = pingXOffsetMax
+        self.pingYOffsetMin = pingYOffsetMin
+        self.pingYOffsetMax = pingYOffsetMax
+        
+        super.init()
+    }
+
+    override var payload: [String : Any] {
+        var payload: [String: Any] = [:]
+                
+        if let selfDescribingEventData = selfDescribingEventData {
+            payload[kSPWebViewEventData] = selfDescribingEventData
+        }
+        if let eventName = eventName {
+            payload[kSPEvent] = eventName
+        }
+        if let trackerVersion = trackerVersion {
+            payload[kSPTrackerVersion] = trackerVersion
+        }
+        if let useragent = useragent {
+            payload[kSPUseragent] = useragent
+        }
+        if let pageUrl = pageUrl {
+            payload[kSPPageUrl] = pageUrl
+        }
+        if let pageTitle = pageTitle {
+            payload[kSPPageTitle] = pageTitle
+        }
+        if let referrer = referrer {
+            payload[kSPPageRefr] = referrer
+        }
+        if let category = category {
+            payload[kSPStructCategory] = category
+        }
+        if let action = action {
+            payload[kSPStructAction] = action
+        }
+        if let label = label {
+            payload[kSPStructLabel] = label
+        }
+        if let property = property {
+            payload[kSPStructProperty] = property
+        }
+        if let value = value {
+            payload[kSPStructValue] = String(value)
+        }
+        if let pingXOffsetMin = pingXOffsetMin {
+            payload[kSPPingXOffsetMin] = String(pingXOffsetMin)
+        }
+        if let pingXOffsetMax = pingXOffsetMax {
+            payload[kSPPingXOffsetMax] = String(pingXOffsetMax)
+        }
+        if let pingYOffsetMin = pingYOffsetMin {
+            payload[kSPPingYOffsetMin] = String(pingYOffsetMin)
+        }
+        if let pingYOffsetMax = pingYOffsetMax {
+            payload[kSPPingYOffsetMax] = String(pingYOffsetMax)
+        }
+        return payload
+    }
+}

--- a/Sources/Core/Tracker/WebViewMessageHandlerV2.swift
+++ b/Sources/Core/Tracker/WebViewMessageHandlerV2.swift
@@ -1,0 +1,138 @@
+//  Copyright (c) 2013-present Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+
+import Foundation
+
+#if os(iOS) || os(macOS) || os(visionOS)
+import WebKit
+
+/// Handler for messages from the JavaScript library embedded in WebViews.
+/// This V2 interface works with the WebView tracker v0.3.0+.
+///
+/// The handler parses messages from the JavaScript library calls and forwards the tracked events to be tracked by the mobile tracker.
+class WebViewMessageHandlerV2: NSObject, WKScriptMessageHandler {
+    /// Callback called when the message handler receives a new message.
+    ///
+    /// The message dictionary should contain three properties:
+    /// 1. "event" with a dictionary containing the event information (structure depends on the tracked event)
+    /// 2. "context" (optional) with a list of self-describing JSONs
+    /// 3. "trackers" (optional) with a list of tracker namespaces to track the event with
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        receivedMessage(message)
+    }
+    
+    func receivedMessage(_ message: WKScriptMessage) {
+        if let body = message.body as? [AnyHashable : Any],
+           let atomicProperties = body["atomicProperties"] as? String {
+            
+            guard let atomicJson = parseAtomicPropertiesFromMessage(atomicProperties) else { return }
+            let selfDescribingDataJson = parseSelfDescribingEventDataFromMessage(body["selfDescribingEventData"] as? String) ?? [:]
+            let entitiesJson = parseEntitiesFromMessage(body["entities"] as? String) ?? []
+            let trackers = body["trackers"] as? [String] ?? []
+            
+            let event = WebViewReader(
+                selfDescribingEventData: createSelfDescribingJson(selfDescribingDataJson),
+                eventName: atomicJson["eventName"] as? String,
+                trackerVersion: atomicJson["trackerVersion"] as? String,
+                useragent: atomicJson["useragent"] as? String,
+                pageUrl: atomicJson["pageUrl"] as? String,
+                pageTitle: atomicJson["pageTitle"] as? String,
+                referrer: atomicJson["referrer"] as? String,
+                category: atomicJson["category"] as? String,
+                action: atomicJson["action"] as? String,
+                label: atomicJson["label"] as? String,
+                property: atomicJson["property"] as? String,
+                value: atomicJson["value"] as? Double,
+                pingXOffsetMin: atomicJson["pingXOffsetMin"] as? Int,
+                pingXOffsetMax: atomicJson["pingXOffsetMax"] as? Int,
+                pingYOffsetMin: atomicJson["pingYOffsetMin"] as? Int,
+                pingYOffsetMax: atomicJson["pingYOffsetMax"] as? Int
+            )
+            
+            track(event, withEntities: entitiesJson, andTrackers: trackers)
+        }
+    }
+    
+    func track(_ event: Event, withEntities entities: [[AnyHashable : Any]], andTrackers trackers: [String]) {
+        event.entities = parseEntities(entities)
+        
+        if trackers.count > 0 {
+            for namespace in trackers {
+                if let tracker = Snowplow.tracker(namespace: namespace) {
+                    _ = tracker.track(event)
+                } else {
+                    logError(message: "WebView: Tracker with namespace \(namespace) not found.")
+                }
+            }
+        } else {
+            _ = Snowplow.defaultTracker()?.track(event)
+        }
+    }
+    
+    func createSelfDescribingJson(_ map: [AnyHashable : Any]) -> SelfDescribingJson? {
+        if let schema = map["schema"] as? String,
+           let payload = map["data"] as? [String : Any] {
+            return SelfDescribingJson(schema: schema, andDictionary: payload)
+        }
+        return nil
+    }
+    
+    func parseEntities(_ entities: [[AnyHashable : Any]]) -> [SelfDescribingJson] {
+        var contextEntities: [SelfDescribingJson] = []
+        
+        for entityJson in entities {
+            if let entity = createSelfDescribingJson(entityJson) {
+                contextEntities.append(entity)
+            }
+        }
+        return contextEntities
+    }
+    
+    func parseAtomicPropertiesFromMessage(_ messageString: String?) -> [String : Any]? {
+        guard let atomicData = messageString?.data(using: .utf8) else {
+            logError(message: "WebView: No atomic properties provided, skipping.")
+            return nil
+        }
+        guard let atomicJson = try? JSONSerialization.jsonObject(with: atomicData) as? [String : Any] else {
+            logError(message: "WebView: Received event payload is not serializable to JSON, skipping.")
+            return nil
+        }
+        return atomicJson
+    }
+    
+    func parseSelfDescribingEventDataFromMessage(_ messageString: String?) -> [String : Any]? {
+        if messageString == nil { return nil }
+        guard let eventData = messageString?.data(using: .utf8),
+              let eventJson = try? JSONSerialization.jsonObject(with: eventData) as? [String : Any] else {
+            logError(message: "WebView: Received event payload is not serializable to JSON, skipping.")
+            return nil
+        }
+        return eventJson
+    }
+    
+    func parseEntitiesFromMessage(_ messageString: String?) -> [[AnyHashable : Any]]? {
+        if messageString == nil { return nil }
+        guard let entitiesData = messageString?.data(using: .utf8),
+              let entitiesJson = try? JSONSerialization.jsonObject(with: entitiesData) as? [[AnyHashable : Any]] else {
+            logError(message: "WebView: Received event payload is not serializable to JSON, skipping.")
+            return nil
+        }
+        return entitiesJson
+    }
+}
+
+
+#endif

--- a/Sources/Core/TrackerConstants.swift
+++ b/Sources/Core/TrackerConstants.swift
@@ -289,3 +289,10 @@ let kSPDiagnosticErrorMessage = "message"
 let kSPDiagnosticErrorStack = "stackTrace"
 let kSPDiagnosticErrorClassName = "className"
 let kSPDiagnosticErrorExceptionName = "exceptionName"
+
+// --- Page Pings (for WebView tracking)
+let kSPPingXOffsetMin = "pp_mix"
+let kSPPingXOffsetMax = "pp_max"
+let kSPPingYOffsetMin = "pp_miy"
+let kSPPingYOffsetMax = "pp_may"
+let kSPWebViewEventData = "selfDescribingEventData"

--- a/Sources/Core/TrackerConstants.swift
+++ b/Sources/Core/TrackerConstants.swift
@@ -181,11 +181,11 @@ let kSPPageTitle = "page"
 let kSPPageRefr = "refr"
 
 // --- Structured Event
-let kSPStuctCategory = "se_ca"
-let kSPStuctAction = "se_ac"
-let kSPStuctLabel = "se_la"
-let kSPStuctProperty = "se_pr"
-let kSPStuctValue = "se_va"
+let kSPStructCategory = "se_ca"
+let kSPStructAction = "se_ac"
+let kSPStructLabel = "se_la"
+let kSPStructProperty = "se_pr"
+let kSPStructValue = "se_va"
 
 // --- E-commerce Transaction Event
 let kSPEcommId = "tr_id"

--- a/Sources/Core/TrackerConstants.swift
+++ b/Sources/Core/TrackerConstants.swift
@@ -14,7 +14,7 @@
 import Foundation
 
 // --- Version
-let kSPRawVersion = "6.0.9"
+let kSPRawVersion = "6.1.0"
 #if os(iOS)
 let kSPVersion = "ios-\(kSPRawVersion)"
 #elseif os(tvOS)

--- a/Sources/Snowplow/Events/Structured.swift
+++ b/Sources/Snowplow/Events/Structured.swift
@@ -53,12 +53,12 @@ public class Structured: PrimitiveAbstract {
 
     override var payload: [String : Any] {
         var payload: [String : Any] = [:]
-        payload[kSPStuctCategory] = category
-        payload[kSPStuctAction] = action
-        if let label = label { payload[kSPStuctLabel] = label }
-        if let property = property { payload[kSPStuctProperty] = property }
+        payload[kSPStructCategory] = category
+        payload[kSPStructAction] = action
+        if let label = label { payload[kSPStructLabel] = label }
+        if let property = property { payload[kSPStructProperty] = property }
         if let value = value {
-            payload[kSPStuctValue] = String(format: "%.17g", value.doubleValue)
+            payload[kSPStructValue] = String(format: "%.17g", value.doubleValue)
         }
         return payload
     }

--- a/Sources/Snowplow/Snowplow.swift
+++ b/Sources/Snowplow/Snowplow.swift
@@ -342,9 +342,11 @@ public class Snowplow: NSObject {
     /// - Parameter webViewConfiguration: Configuration of the Web view to subscribe to events from
     @objc
     public class func subscribeToWebViewEvents(with webViewConfiguration: WKWebViewConfiguration) {
-        let messageHandler = WebViewMessageHandler()
+        let messageHandlerOld = WebViewMessageHandler()
+        let messageHandlerV2 = WebViewMessageHandlerV2()
 
-        webViewConfiguration.userContentController.add(messageHandler, name: "snowplow")
+        webViewConfiguration.userContentController.add(messageHandlerOld, name: "snowplow")
+        webViewConfiguration.userContentController.add(messageHandlerV2, name: "snowplowV2")
     }
 
     #endif

--- a/Tests/Global Contexts/TestGlobalContexts.swift
+++ b/Tests/Global Contexts/TestGlobalContexts.swift
@@ -18,7 +18,7 @@ import XCTest
 
 class GlobalContextGenerator: NSObject, ContextGenerator {
     func filter(from event: InspectableEvent) -> Bool {
-        return "StringToMatch" == event.payload[kSPStuctCategory] as? String
+        return "StringToMatch" == event.payload[kSPStructCategory] as? String
     }
 
     func generator(from event: InspectableEvent) -> [SelfDescribingJson]? {
@@ -151,7 +151,7 @@ class TestGlobalContexts: XCTestCase {
                 ])
             ],
             filter: { event in
-                return stringToMatch == event.payload[kSPStuctCategory] as? String
+                return stringToMatch == event.payload[kSPStructCategory] as? String
             })
         let filterNotMatchingGC = GlobalContext(staticContexts: [
             SelfDescribingJson(schema: "schemaNotMatching", andDictionary: [

--- a/Tests/TestWebViewMessageHandlerV2.swift
+++ b/Tests/TestWebViewMessageHandlerV2.swift
@@ -1,0 +1,228 @@
+//  Copyright (c) 2013-present Snowplow Analytics Ltd. All rights reserved.
+//
+//  This program is licensed to you under the Apache License Version 2.0,
+//  and you may not use this file except in compliance with the Apache License
+//  Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+//  http://www.apache.org/licenses/LICENSE-2.0.
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the Apache License Version 2.0 is distributed on
+//  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+//  express or implied. See the Apache License Version 2.0 for the specific
+//  language governing permissions and limitations there under.
+
+#if os(iOS) || os(macOS) || os(visionOS)
+import XCTest
+@testable import SnowplowTracker
+
+class TestWebViewMessageHandlerV2: XCTestCase {
+    var webViewMessageHandler: WebViewMessageHandlerV2?
+
+    override func setUp() {
+        webViewMessageHandler = WebViewMessageHandlerV2()
+        Snowplow.removeAllTrackers()
+    }
+
+    override func tearDown() {
+        Snowplow.removeAllTrackers()
+    }
+    
+    func testTracksEventWithAllProperties() {
+        let networkConnection = MockNetworkConnection(requestOption: .post, statusCode: 200)
+        let networkConfig = NetworkConfiguration(networkConnection: networkConnection)
+        let trackerConfig = TrackerConfiguration().base64Encoding(false)
+
+        _ = Snowplow.createTracker(
+            namespace: UUID().uuidString,
+            network: networkConfig,
+            configurations: [trackerConfig]
+        )
+        
+        let data = "{\"schema\":\"iglu:etc\",\"data\":{\"key\":\"val\"}}"
+        let atomic = "{\"eventName\":\"pv\",\"trackerVersion\":\"webview\"," +
+                "\"useragent\":\"Chrome\",\"pageUrl\":\"http://snowplow.com\"," +
+                "\"pageTitle\":\"Snowplow\",\"referrer\":\"http://google.com\"," +
+                "\"pingXOffsetMin\":10,\"pingXOffsetMax\":20,\"pingYOffsetMin\":30," +
+                "\"pingYOffsetMax\":40,\"category\":\"cat\",\"action\":\"act\"," +
+                "\"property\":\"prop\",\"label\":\"lbl\",\"value\":10.0}"
+        
+        let message = MockWKScriptMessage(
+            body: [
+                "atomicProperties": atomic,
+                "selfDescribingEventData": data,
+            ])
+        webViewMessageHandler?.receivedMessage(message)
+
+        waitForEventsToBeTracked()
+
+        XCTAssertEqual(1, networkConnection.sendingCount)
+        XCTAssertEqual(1, (networkConnection.previousRequests)[0].count)
+        
+        let request = (networkConnection.previousRequests)[0][0]
+        let payload = (request.payload?["data"] as? [[String: Any]])?[0]
+        
+        XCTAssert(payload?[kSPEvent] as? String == "pv")
+        XCTAssert(payload?[kSPTrackerVersion] as? String == "webview")
+        XCTAssert(payload?[kSPUseragent] as? String == "Chrome")
+        XCTAssert(payload?[kSPPageUrl] as? String == "http://snowplow.com")
+        XCTAssert(payload?[kSPPageTitle] as? String == "Snowplow")
+        XCTAssert(payload?[kSPPageRefr] as? String == "http://google.com")
+        XCTAssert(payload?[kSPPingXOffsetMin] as? String == "10")
+        XCTAssert(payload?[kSPPingXOffsetMax] as? String == "20")
+        XCTAssert(payload?[kSPPingYOffsetMin] as? String == "30")
+        XCTAssert(payload?[kSPPingYOffsetMax] as? String == "40")
+        XCTAssert(payload?[kSPStructCategory] as? String == "cat")
+        XCTAssert(payload?[kSPStructAction] as? String == "act")
+        XCTAssert(payload?[kSPStructProperty] as? String == "prop")
+        XCTAssert(payload?[kSPStructLabel] as? String == "lbl")
+        XCTAssert(payload?[kSPStructValue] as? String == "10.0")
+        
+        XCTAssertTrue(payload?[kSPUnstructured] != nil)
+        
+        if let unstructuredJson = payload?[kSPUnstructured] as? String,
+           let jsonData = unstructuredJson.data(using: .utf8),
+           let selfDescJson = try? JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any] {
+            XCTAssert(selfDescJson["schema"] as? String == kSPUnstructSchema)
+            
+            if let data = selfDescJson["data"] as? [String : Any] {
+                XCTAssert(data["schema"] as? String == "iglu:etc")
+                
+                if let customData = data["data"] as? [String : Any] {
+                    XCTAssert(customData["key"] as? String == "val")
+                }
+            }
+        }
+    }
+    
+    func testAddsDefaultPropertiesIfNotProvided() {
+        let networkConnection = MockNetworkConnection(requestOption: .post, statusCode: 200)
+        let networkConfig = NetworkConfiguration(networkConnection: networkConnection)
+        let trackerConfig = TrackerConfiguration().base64Encoding(false)
+
+        Snowplow.removeAllTrackers()
+        _ = Snowplow.createTracker(
+            namespace: UUID().uuidString,
+            network: networkConfig,
+            configurations: [trackerConfig]
+        )
+        
+        let message = MockWKScriptMessage(body: ["atomicProperties": "{}"])
+        webViewMessageHandler?.receivedMessage(message)
+
+        waitForEventsToBeTracked()
+
+        XCTAssertEqual(1, (networkConnection.previousRequests)[0].count)
+        
+        let request = (networkConnection.previousRequests)[0][0]
+        let payload = (request.payload?["data"] as? [[String: Any]])?[0]
+        
+        XCTAssert(payload?[kSPEvent] as? String == "ue")
+        
+        if let trackerVersion = payload?[kSPTrackerVersion] as? String {
+            XCTAssertTrue(trackerVersion.range(of: #"^(ios|watchos|tvos|osx)"#, options: .regularExpression) != nil)
+        }
+    }
+
+    func testTracksEventWithCorrectTracker() {
+        let eventSink1 = EventSink()
+        let eventSink2 = EventSink()
+
+        _ = createTracker("ns1", eventSink1)
+        _ = createTracker("ns2", eventSink2)
+        Thread.sleep(forTimeInterval: 0.2)
+        
+        // track an event using the second tracker
+        let message = MockWKScriptMessage(
+            body: [
+                "atomicProperties": "{}",
+                "trackers": ["ns2"]
+            ])
+        webViewMessageHandler?.receivedMessage(message)
+        Thread.sleep(forTimeInterval: 0.2)
+        
+        XCTAssertEqual(0, eventSink1.trackedEvents.count)
+        XCTAssertEqual(1, eventSink2.trackedEvents.count)
+        
+        // tracks using default tracker if not specified
+        let message2 = MockWKScriptMessage(body: ["atomicProperties": "{}"])
+        webViewMessageHandler?.receivedMessage(message2)
+        Thread.sleep(forTimeInterval: 0.2)
+        
+        XCTAssertEqual(1, eventSink1.trackedEvents.count)
+        XCTAssertEqual(1, eventSink2.trackedEvents.count)
+    }
+
+    func testTracksEventWithEntity() {
+        let eventSink = EventSink()
+        _ = createTracker("ns" + String(describing: Int.random(in: 0..<100)), eventSink)
+        Thread.sleep(forTimeInterval: 0.2)
+        
+        let message = MockWKScriptMessage(
+            body: [
+                "atomicProperties": "{}",
+                "entities": "[{\"schema\":\"iglu:com.example/etc\",\"data\":{\"key\":\"val\"}}]"
+            ])
+        webViewMessageHandler?.receivedMessage(message)
+        Thread.sleep(forTimeInterval: 0.2)
+        
+        XCTAssertEqual(1, eventSink.trackedEvents.count)
+        let relevantEntities = eventSink.trackedEvents[0].entities.filter { $0.schema == "iglu:com.example/etc" }
+        
+        XCTAssertEqual(1, relevantEntities.count)
+        
+        let entityData = relevantEntities[0].dictionary["data"] as? [String : Any]
+        XCTAssertEqual("val", entityData?["key"] as? String)
+    }
+    
+    func testAddsEventNameAndSchemaForInspection() {
+        let eventSink = EventSink()
+        _ = createTracker("ns" + String(describing: Int.random(in: 0..<100)), eventSink)
+        Thread.sleep(forTimeInterval: 0.2)
+        
+        let message = MockWKScriptMessage(
+            body: [
+                "atomicProperties": "{\"eventName\":\"se\"}",
+                "selfDescribingEventData": "{\"schema\":\"iglu:etc\",\"data\":{\"key\":\"val\"}}"
+            ])
+        webViewMessageHandler?.receivedMessage(message)
+        Thread.sleep(forTimeInterval: 0.2)
+        
+        let events = eventSink.trackedEvents
+        
+        XCTAssertEqual(1, events.count)
+        XCTAssertEqual("se", events[0].eventName)
+        XCTAssertEqual("iglu:etc", events[0].schema)
+    }
+    
+    func testHandlesNonJSONSerializableDataInEvent() {
+        let message = MockWKScriptMessage(
+            body: [
+                "atomicProperties": "{\"eventName\":\"se\"}",
+                "selfDescribingEventData": Double.nan
+            ])
+        webViewMessageHandler?.receivedMessage(message) // shouldn't crash
+    }
+    
+    func testHandlesMissingAtomicPropertiesInEvent() {
+        let message = MockWKScriptMessage(body: [])
+        webViewMessageHandler?.receivedMessage(message) // shouldn't crash
+    }
+        
+    private func waitForEventsToBeTracked() {
+        let expect = expectation(description: "Wait for events to be tracked")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { () -> Void in
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: 1)
+    }
+    
+    private func createTracker(_ namespace: String, _ eventSink: EventSink) -> TrackerController {
+        let networkConfig = NetworkConfiguration(networkConnection: MockNetworkConnection(requestOption: .post, statusCode: 200))
+        let trackerConfig = TrackerConfiguration().base64Encoding(false)
+        
+        return Snowplow.createTracker(namespace: namespace,
+                                      network: networkConfig,
+                                      configurations: [trackerConfig, eventSink])
+    }
+}
+#endif


### PR DESCRIPTION
This version makes tracking in hybrid apps easier and more powerful, by adding support for the new [Snowplow JavaScript tracker](https://github.com/snowplow/snowplow-javascript-tracker) WebView plugin (available from JS tracker v4.3).

Implement the JS tracker plus WebView plugin in your WebView to automatically forward all web events to the iOS tracker.

### Enhancements
* Add new WebView interface (#913)

### Under the hood
* Fix typos in internal Structured event constants (#911)