### PR TITLE
Release/6.2.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 6.2.1 (2025-04-03)
+--------------------------
+Fix handling NaN and infinite current time in media player stats
+
 Version 6.2.0 (2025-02-11)
 --------------------------
 Add an option to continue previously persisted session when the app restarts rather than starting a new one (#912)

--- a/SnowplowTracker.podspec
+++ b/SnowplowTracker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "SnowplowTracker"
-    s.version          = "6.2.0"
+    s.version          = "6.2.1"
     s.summary          = "Snowplow event tracker for iOS, macOS, tvOS, watchOS for apps and games."
     s.description      = <<-DESC
     Snowplow is a mobile and event analytics platform with a difference: rather than tell our users how they should analyze their data, we deliver their event-level data in their own data warehouse, on their own Amazon Redshift or Postgres database, so they can analyze it any way they choose. Snowplow mobile is used by data-savvy games companies and app developers to better understand their users and how they engage with their games and applications. Snowplow is open source using the business-friendly Apache License, Version 2.0 and scales horizontally to many billions of events.

--- a/Sources/Core/TrackerConstants.swift
+++ b/Sources/Core/TrackerConstants.swift
@@ -14,7 +14,7 @@
 import Foundation
 
 // --- Version
-let kSPRawVersion = "6.2.0"
+let kSPRawVersion = "6.2.1"
 #if os(iOS)
 let kSPVersion = "ios-\(kSPRawVersion)"
 #elseif os(tvOS)

--- a/Sources/Snowplow/Media/Entities/MediaPlayerEntity.swift
+++ b/Sources/Snowplow/Media/Entities/MediaPlayerEntity.swift
@@ -44,7 +44,15 @@ extension MediaType {
 @objc(SPMediaPlayer)
 public class MediaPlayerEntity: NSObject {
     /// The current playback time position within the media in seconds
-    public var currentTime: Double?
+    private var _currentTime: Double?
+    public var currentTime: Double? {
+        set {
+            if newValue?.isNaN != true && newValue?.isInfinite != true {
+                _currentTime = newValue
+            }
+        }
+        get { return _currentTime }
+    }
     /// A double-precision floating-point value indicating the duration of the media in seconds
     public var duration: Double?
     /// If playback of the media has ended
@@ -138,6 +146,7 @@ public class MediaPlayerEntity: NSObject {
                 playbackRate: Double? = nil,
                 quality: String? = nil,
                 volume: Int? = nil) {
+        super.init()
         self.currentTime = currentTime
         self.duration = duration
         self.ended = ended

--- a/Tests/Media/TestMediaSessionTrackingStats.swift
+++ b/Tests/Media/TestMediaSessionTrackingStats.swift
@@ -252,4 +252,25 @@ class TestMediaSessionTrackingStats: XCTestCase {
         XCTAssertEqual(60, stats.timePlayed)
         XCTAssertEqual(31, stats.timeBuffering)
     }
+    
+    func testNaNAndInfCurrentTime() {
+        guard let stats = stats else { return XCTFail() }
+        let mediaPlayer = MediaPlayerEntity(paused: false)
+        
+        stats.update(event: MediaPlayEvent(), player: mediaPlayer)
+        
+        mediaPlayer.currentTime = Double.nan
+        stats.update(event: MediaEndEvent(), player: mediaPlayer)
+        
+        XCTAssertEqual(0, stats.timePlayed)
+        XCTAssertEqual(0, stats.timePlayedMuted)
+        XCTAssertEqual(0, stats.timePaused)
+        
+        mediaPlayer.currentTime = Double.infinity
+        stats.update(event: MediaEndEvent(), player: mediaPlayer)
+
+        XCTAssertEqual(0, stats.timePlayed)
+        XCTAssertEqual(0, stats.timePlayedMuted)
+        XCTAssertEqual(0, stats.timePaused)
+    }
 }


### PR DESCRIPTION
This release fixes an issue in the media tracking that could cause the app to crash in case of infinite or nan playback position information being tracked.

**Bug fixes**

- Fix handling NaN and infinite current time in media player stats