### PR TITLE
Fix memory leak in `RemoteConfigurationProvider`

### DIFF
--- a/Sources/Core/RemoteConfiguration/RemoteConfigurationProvider.swift
+++ b/Sources/Core/RemoteConfiguration/RemoteConfigurationProvider.swift
@@ -58,7 +58,9 @@ class RemoteConfigurationProvider {
                 }
             }
         }
-        fetcher = RemoteConfigurationFetcher(remoteSource: remoteConfiguration) { bundle, state in
+        fetcher = RemoteConfigurationFetcher(remoteSource: remoteConfiguration) { [weak self] bundle, state in
+            guard let self else { return }
+
             if !self.schemaCompatibility(bundle.schema) {
                 return
             }


### PR DESCRIPTION
Declare `[weak self]` in `RemoteConfigurationProvider`'s callback passed to `RemoteConfigurationProvider` object.